### PR TITLE
return stack for merkle proof

### DIFF
--- a/baseTrie.js
+++ b/baseTrie.js
@@ -73,7 +73,7 @@ Trie.prototype.get = function (key, cb) {
       value = node.value
     }
 
-    cb(err, value)
+    cb(err, value, stack)
   })
 }
 


### PR DESCRIPTION
This is a very easy way to enable the extraction of merkleproof data from this js module. Literally a one-line change. It does not break the existing API and only passes a reference (so no performance decreases either).

This data has everything needed to make the merkleproof (although it may be useful to reformat it into a standard like open-timestamp or chainpoint). I am creating a module to do the rest of the work and verify the proofs. Happy to merge it in this repo as well (if you want).