### PR TITLE
walkTrie - rename 'root' arg to 'nodeRef'

### DIFF
--- a/checkpoint-interface.js
+++ b/checkpoint-interface.js
@@ -171,9 +171,9 @@ ScratchReadStream.prototype._read = function () {
   var self = this
   if (!self._started) {
     self._started = true
-    self.trie._findDbNodes(function (root, node, key, next) {
+    self.trie._findDbNodes(function (nodeRef, node, key, next) {
       self.push({
-        key: root,
+        key: nodeRef,
         value: node.serialize()
       })
       next()

--- a/readStream.js
+++ b/readStream.js
@@ -18,7 +18,7 @@ TrieReadStream.prototype._read = function () {
   var self = this
   if (!self._started) {
     self._started = true
-    self.trie._findValueNodes(function (root, node, key, next) {
+    self.trie._findValueNodes(function (nodeRef, node, key, next) {
       self.push({
         key: TrieNode.nibblesToBuffer(key),
         value: node.value


### PR DESCRIPTION
easier to understand

nodeRef is either a hash or a rawNode, depending on how the node is stored in the trie