### PR TITLE
Fix race condition due to mutated _getDBs/_putDBs

### DIFF
--- a/checkpoint-interface.js
+++ b/checkpoint-interface.js
@@ -93,7 +93,7 @@ function _enterCpMode () {
   this._scratch = levelup('', {
     db: memdown
   })
-  this._getDBs.unshift(this._scratch)
+  this._getDBs = [this._scratch].concat(this._getDBs)
   this.__putDBs = this._putDBs
   this._putDBs = [this._scratch]
   this._putRaw = this.putRaw
@@ -105,7 +105,7 @@ function _exitCpMode (commitState, cb) {
   var self = this
   var scratch = this._scratch
   this._scratch = null
-  this._getDBs.shift()
+  this._getDBs = this._getDBs.slice(1)
   this._putDBs = this.__putDBs
   this.putRaw = this._putRaw
 


### PR DESCRIPTION
This fixes part of the issues described in https://github.com/trufflesuite/ganache-cli/issues/417.

The `asyncFirstSeries` function called inside `Trie#getRaw` was iterating over an array that could be mutated by the checkpoint `_enterCpMode`/`_exitCpMode ` functions, causing the familiar `TypeError: Cannot read property 'get' of undefined`.

I replaced the mutations with reassignments.

Note that the tests written in https://github.com/trufflesuite/ganache-core/pull/41 still fail, now both with the same error: `TypeError: Cannot read property 'pop' of undefined`.