### PR TITLE
`get` / `pop` of `undefined`

### DIFF
--- a/baseTrie.js
+++ b/baseTrie.js
@@ -65,15 +65,16 @@ function Trie (db, root) {
 Trie.prototype.get = function (key, cb) {
   var self = this
 
-  key = ethUtil.toBuffer(key)
-
-  self.findPath(key, function (err, node, remainder, stack) {
-    var value = null
-    if (node && remainder.length === 0) {
-      value = node.value
-    }
-
-    cb(err, value)
+  cb = callTogether(cb, self.sem.leave)
+  self.sem.take(function () {
+    key = ethUtil.toBuffer(key)
+    self.findPath(key, function (err, node, remainder, stack) {
+      var value = null
+      if (node && remainder.length === 0) {
+        value = node.value
+      }
+      cb(err, value)
+    })
   })
 }
 
@@ -142,9 +143,23 @@ Trie.prototype.del = function (key, cb) {
  * Retrieves a raw value in the underlying db
  * @method getRaw
  * @param {Buffer} key
- * @param {Function} callback A callback `Function`, which is given the arguments `err` - for errors that may have occured and `value` - the found value in a `Buffer` or if no value was found `null`.
+ * @param {Function} cb A callback `Function`, which is given the arguments `err` - for errors that may have occured and `value` - the found value in a `Buffer` or if no value was found `null`.
+ * @param {Boolean} locked flag to
  */
-Trie.prototype.getRaw = function (key, cb) {
+
+Trie.prototype.getRaw = function (key, cb, locked) {
+  var self = this
+  if (!locked) {
+    cb = callTogether(cb, this.sem.leave)
+    self.sem.take(function () {
+      self._getRaw(key, cb)
+    })
+  }
+  else {
+    self._getRaw(key, cb)
+  }
+}
+Trie.prototype._getRaw = function (key, cb) {
   key = ethUtil.toBuffer(key)
 
   function dbGet (db, cb2) {
@@ -159,6 +174,7 @@ Trie.prototype.getRaw = function (key, cb) {
       }
     })
   }
+  // TODO (clehene) replace with async.race / async.tryEach
   asyncFirstSeries(this._getDBs, dbGet, cb)
 }
 
@@ -177,7 +193,7 @@ Trie.prototype._lookupNode = function (node, cb) {
       }
 
       cb(value)
-    })
+    }, true)
   }
 }
 
@@ -311,24 +327,27 @@ Trie.prototype._findNode = function (key, root, stack, cb) {
  * Finds all nodes that store k,v values
  */
 Trie.prototype._findValueNodes = function (onFound, cb) {
-  this._walkTrie(this.root, function (nodeRef, node, key, walkController) {
-    var fullKey = key
+  cb = callTogether(cb, this.sem.leave)
+  this.sem.take(function () {
+    this._walkTrie(this.root, function (nodeRef, node, key, walkController) {
+      var fullKey = key
 
-    if (node.key) {
-      fullKey = key.concat(node.key)
-    }
+      if (node.key) {
+        fullKey = key.concat(node.key)
+      }
 
-    if (node.type === 'leaf') {
-      // found leaf node!
-      onFound(nodeRef, node, fullKey, walkController.next)
-    } else if (node.type === 'branch' && node.value) {
-      // found branch with value
-      onFound(nodeRef, node, fullKey, walkController.next)
-    } else {
-      // keep looking for value nodes
-      walkController.next()
-    }
-  }, cb)
+      if (node.type === 'leaf') {
+        // found leaf node!
+        onFound(nodeRef, node, fullKey, walkController.next)
+      } else if (node.type === 'branch' && node.value) {
+        // found branch with value
+        onFound(nodeRef, node, fullKey, walkController.next)
+      } else {
+        // keep looking for value nodes
+        walkController.next()
+      }
+    }, cb)
+  })
 }
 
 /*
@@ -746,7 +765,10 @@ Trie.prototype.batch = function (ops, cb) {
  */
 Trie.prototype.checkRoot = function (root, cb) {
   root = ethUtil.toBuffer(root)
-  this._lookupNode(root, function (value) {
-    cb(null, !!value)
+  cb = callTogether(cb, self.sem.leave)
+  self.sem.take(function () {
+    this._lookupNode(root, function (value) {
+      cb(null, !!value)
+    })
   })
 }

--- a/util.js
+++ b/util.js
@@ -58,21 +58,24 @@ function callTogether () {
 /**
  * Take a collection of async fns, call the cb on the first to return a truthy value.
  * If all run without a truthy result, return undefined
+ *
+ * TODO replace with async race / tryEach
+ * intended behavior depends on swallowing any  error
  */
-function asyncFirstSeries (array, iterator, cb) {
+function asyncFirstSeries (array, processItem, cb) {
   var didComplete = false
   async.eachSeries(array, function (item, next) {
     if (didComplete) return next
-    iterator(item, function (err, result) {
-      if (result) {
+    processItem(item, function (err, returnVal) {
+      if (returnVal) {
         didComplete = true
-        process.nextTick(cb.bind(null, null, result))
+        process.nextTick(cb.bind(null, null, returnVal))
       }
       next(err)
     })
-  }, function () {
+  }, function (err) {
     if (!didComplete) {
-      cb()
+      cb({'err': 'no result'})
     }
   })
 }


### PR DESCRIPTION
Fixes conditions described in https://github.com/trufflesuite/ganache-cli/issues/453 and https://github.com/trufflesuite/ganache-cli/issues/417

`get` on `undefined` is caused by races around `getDBs` 

When doing a checkpoint we end up with two dbs and all reads (getRaw->db.get) happen on both asynchronously. When things are committed or reverted the second db goes away and the in-flight get will try the second instance (think `db[0] / db[1]`) that's not there anymore and fail with undefined .

One case (in `getRaw`) was trickier and is partially a break of encapsulation problem: `getRaw` should probably be private but is called directly from Account.

This means that access needs to be synchronized around anything that would race for db instances.
Many of the operations were already using semaphores for this however some didn't (e.g. `checkpoint`, `get`). The problem with the last race was due to direct access to `getRaw` from `Account.prototype.getCode`. Again IMO this is mostly an encapsulation problem as get should probably be used instead (and perhaps that's the right fix, although I'd say it would also require making `getRaw` "private".
The alternative (which is what is include in the patch) for a local fix is to mark the under-lock state with a flag (param), based on which's absence (if flag is off) the semaphore can be acquired to avoid the race.

The pop issue, is  a logical one and happened due to propagation (or lack thereof) of `not found` errors from `db.get` operations. 

Lastly, the merkle-patricia-tree code is more complex than it perhaps should given the functionality (deep callback stack, mutual recursion, heavy async, etc.). In addition the stuff around it, there may be other issues lying around,

As a caveat - now with the get / pop issues out of the way I can sometimes see
* https://github.com/trufflesuite/truffle/issues/558
* https://github.com/trufflesuite/ganache-cli/issues/433

Initially I was concerned that they were somehow introduced by these fixes and tried to see how but that wasn't the case (not sure how they occur though) however I've confirmed them without the fixes as well.