### PR TITLE
Fix OutOfMemory in read stream

### DIFF
--- a/prioritizedTaskExecutor.js
+++ b/prioritizedTaskExecutor.js
@@ -1,0 +1,43 @@
+module.exports = PrioritizedTaskExecutor
+
+/**
+ * Executes tasks up to maxPoolSize at a time, other items are put in a priority queue.
+ * @class PrioritizedTaskExecutor
+ * @param {Number} maxPoolSize The maximum size of the pool
+ * @prop {Number} maxPoolSize The maximum size of the pool
+ * @prop {Number} currentPoolSize The current size of the pool
+ * @prop {Array} queue The task queue
+ */
+function PrioritizedTaskExecutor (maxPoolSize) {
+  this.maxPoolSize = maxPoolSize
+  this.currentPoolSize = 0
+  this.queue = []
+}
+
+/**
+ * Executes the task.
+ * @param {Number} priority The priority of the task
+ * @param {Function} task The function that accepts the callback, which must be called upon the task completion.
+ */
+PrioritizedTaskExecutor.prototype.execute = function (priority, task) {
+  var self = this
+
+  if (self.currentPoolSize < self.maxPoolSize) {
+    self.currentPoolSize++
+    task(function () {
+      self.currentPoolSize--
+      if (self.queue.length > 0) {
+        self.queue.sort(function (a, b) {
+          return b.priority - a.priority
+        })
+        var item = self.queue.shift()
+        self.execute(item.priority, item.task)
+      }
+    })
+  } else {
+    self.queue.push({
+      priority: priority,
+      task: task
+    })
+  }
+}

--- a/test/prioritizedTaskExecutor.js
+++ b/test/prioritizedTaskExecutor.js
@@ -1,0 +1,23 @@
+const PrioritizedTaskExecutor = require('../prioritizedTaskExecutor.js')
+const tape = require('tape')
+const taskExecutor = new PrioritizedTaskExecutor(2)
+
+tape('prioritized task executor test', function (t) {
+  var tasks = [1, 2, 3, 4]
+  var callbacks = []
+  var executionOrder = []
+  tasks.forEach(function (task) {
+    taskExecutor.execute(task, function (cb) {
+      executionOrder.push(task)
+      callbacks.push(cb)
+    })
+  })
+
+  callbacks.forEach(function (callback) {
+    callback()
+  })
+
+  var expectedExecutionOrder = [1, 2, 4, 3]
+  t.deepEqual(executionOrder, expectedExecutionOrder)
+  t.end()
+})


### PR DESCRIPTION
Fix for https://github.com/ethereumjs/merkle-patricia-tree/issues/36

The root cause of the issue is the trie is traversed asynchronously, in such a way that nodes on different levels are explored with equal probability, resembling breadth-first search. This requires the bulk of the trie to be loaded into memory before any entries can be emitted by the stream.

This pull request adds `PrioritizedTaskExecutor` with a pool and a priority queue, node lookups are prioritised by node key length. This resembles depth-first search, which solves the issue.

Also tested here https://github.com/medvedev1088/merkle-patricia-tree/pull/1

New code is covered in `test/prioritizedTaskExecutor.js` but coverage only picks `test/index.js`