### PR TITLE
fix _scratch 'leak' to global/window

### DIFF
--- a/checkpoint-interface.js
+++ b/checkpoint-interface.js
@@ -129,7 +129,7 @@ function _exitCpMode (commitState, cb) {
 // adds the interface when copying the trie
 function copy (_super) {
   var trie = _super()
-  checkpointInterface(trie)
+  checkpointInterface.call(trie, trie)
   trie._scratch = this._scratch
   // trie._checkpoints = this._checkpoints.slice()
   return trie

--- a/index.js
+++ b/index.js
@@ -9,9 +9,8 @@ inherits(CheckpointTrie, BaseTrie)
 
 function CheckpointTrie () {
   BaseTrie.apply(this, arguments)
-  checkpointInterface(this)
+  checkpointInterface.call(this, this)
 }
 
 CheckpointTrie.prove = proof.prove
 CheckpointTrie.verifyProof = proof.verifyProof
-


### PR DESCRIPTION
`_scratch` was leaking because `checkpointInterface` was called without assigning `this` (in strict mode it would fail because `this` would be undefined, otherwise it takes global/window as 'this', hence the leak)
I'm not familiar with tape, if there's an option to check leaks (like --check-leaks in mocha) it would be great to use - it will never happen again in the future. I didn't find something similar to that in tape.

```javascript
function checkpointInterface (trie) {
  this._scratch = null // before the fix `this` may be global, window or undefined
  // ...
}
```