### PR TITLE
Fix coverage to run all scripts under tape

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "npm run test:node && npm run test:browser",
-    "coverage": "istanbul cover ./test/index.js",
+    "coverage": "istanbul cover tape ./test/*.js",
     "coveralls": "npm run coverage && coveralls <coverage/lcov.info",
     "lint": "standard",
     "prepublish": "npm run build",


### PR DESCRIPTION
This PR fixes the coverage report, which appeared to only be running for tests under index.js.

