### PR TITLE
Replace levelup+memdown with level-mem 3.0.1 and upgrade level-ws to 1.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
 language: node_js
 node_js:
-  - "4"
-  - "5"
   - "6"
-  - "7"
   - "8"
   - "9"
+  - "10"
 env:
   - CXX=g++-4.8
 addons:
@@ -35,5 +33,3 @@ matrix:
       env: CXX=g++-4.8 TEST_SUITE=test:browser
 script: npm run $TEST_SUITE
 
-notifications:
-  irc: "chat.freenode.net#ethereumjs"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# SYNOPSIS 
+# SYNOPSIS
 [![NPM Package](https://img.shields.io/npm/v/merkle-patricia-tree.svg?style=flat-square)](https://www.npmjs.org/package/merkle-patricia-tree)
 [![Build Status](https://img.shields.io/travis/ethereumjs/merkle-patricia-tree.svg?branch=master&style=flat-square)](https://travis-ci.org/ethereumjs/merkle-patricia-tree)
 [![Coverage Status](https://img.shields.io/coveralls/ethereumjs/merkle-patricia-tree.svg?style=flat-square)](https://coveralls.io/r/ethereumjs/merkle-patricia-tree)
@@ -22,9 +22,9 @@ The only backing store supported is LevelDB through the ```levelup``` module.
 
 ```javascript
 var Trie = require('merkle-patricia-tree'),
-levelup = require('levelup'),
-db = levelup('./testdb'),
-trie = new Trie(db); 
+level = require('level'),
+db = level('./testdb'),
+trie = new Trie(db);
 
 trie.put('test', 'one', function () {
   trie.get('test', function (err, value) {
@@ -49,19 +49,19 @@ Trie.prove(trie, 'test', function (err, prove) {
 ## Read stream on Geth DB
 
 ```javascript
-var levelup = require('levelup')
+var level = require('level')
 var Trie = require('./secure')
 
 var stateRoot = "0xd7f8974fb5ac78d9ac099b9ad5018bedc2ce0a72dad1827a1709da30580f0544" // Block #222
 
-var db = levelup('YOUR_PATH_TO_THE_GETH_CHAIN_DB')
+var db = level('YOUR_PATH_TO_THE_GETH_CHAIN_DB')
 var trie = new Trie(db, stateRoot)
 
 trie.createReadStream()
   .on('data', function (data) {
     console.log(data)
   })
-  .on('end', function() { 
+  .on('end', function() {
     console.log('End.')
   })
 ```

--- a/baseTrie.js
+++ b/baseTrie.js
@@ -1,6 +1,5 @@
 const assert = require('assert')
-const levelup = require('levelup')
-const memdown = require('memdown')
+const level = require('level-mem')
 const async = require('async')
 const rlp = require('rlp')
 const ethUtil = require('ethereumjs-util')
@@ -19,7 +18,7 @@ module.exports = Trie
  * Use `require('merkel-patricia-tree')` for the base interface. In Ethereum applications stick with the Secure Trie Overlay `require('merkel-patricia-tree/secure')`. The API for the raw and the secure interface are about the same
  * @class Trie
  * @param {Object} [db] An instance of [levelup](https://github.com/rvagg/node-levelup/) or a compatible API. If the db is `null` or left undefined, then the trie will be stored in memory via [memdown](https://github.com/rvagg/memdown)
- * @param {Buffer|String} [root]` A hex `String` or `Buffer` for the root of a previously stored trie
+ * @param {Buffer|String} [root] A hex `String` or `Buffer` for the root of a previously stored trie
  * @prop {Buffer} root The current root of the `trie`
  * @prop {Boolean} isCheckpoint  determines if you are saving to a checkpoint or directly to the db
  * @prop {Buffer} EMPTY_TRIE_ROOT the Root for an empty trie
@@ -30,10 +29,7 @@ function Trie (db, root) {
   this.sem = semaphore(1)
 
   // setup dbs
-  this.db = db ||
-    levelup('', {
-      db: memdown
-    })
+  this.db = db || level()
 
   this._getDBs = [this.db]
   this._putDBs = [this.db]

--- a/package.json
+++ b/package.json
@@ -35,9 +35,8 @@
   "dependencies": {
     "async": "^1.4.2",
     "ethereumjs-util": "^5.0.0",
-    "level-ws": "0.0.0",
-    "levelup": "^1.2.1",
-    "memdown": "^1.0.0",
+    "level-ws": "^1.0.0",
+    "level-mem": "^3.0.1",
     "readable-stream": "^2.0.0",
     "rlp": "^2.0.0",
     "semaphore": ">=1.0.1"


### PR DESCRIPTION
See: https://github.com/ethereumjs/ethereumjs-client/issues/53

The current versions of the levelup, memdown and level-ws modules are very old. This PR replaces these with modern and up-to-date versions. There were some minor breaking API changes with the new versions so some code had to be modified.

Also, the newer versions of the level modules only support node 6 and higher.

All tests are passing but I'm not sure what the best way to make sure other external dependencies aren't broken. Ideas?