### PR TITLE
Add package-lock.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+package-lock.json
 node_modules
 dist/
 


### PR DESCRIPTION
This PR adds the `package-lock.json` file to the Git ignore list.