### PR TITLE
Fix prove and verifyProof in SecureTrie

### DIFF
--- a/src/secure.js
+++ b/src/secure.js
@@ -14,6 +14,16 @@ module.exports = class SecureTrie extends CheckpointTrie {
     super(...args)
   }
 
+  static prove (trie, key, cb) {
+    const hash = ethUtil.keccak256(key)
+    super.prove(trie, hash, cb)
+  }
+
+  static verifyProof (rootHash, key, proof, cb) {
+    const hash = ethUtil.keccak256(key)
+    super.verifyProof(rootHash, hash, proof, cb)
+  }
+
   copy () {
     const db = this.db.copy()
     return new SecureTrie(db, this.root)

--- a/test/secure.js
+++ b/test/secure.js
@@ -28,6 +28,30 @@ tape('SecureTrie', function (t) {
   })
 })
 
+tape('SecureTrie proof', function (t) {
+  t.test('create a merkle proof and verify it with a single short key', function (st) {
+    const trie = new Trie()
+
+    async.series([
+      function (cb) {
+        trie.put('key1aa', '01234', cb)
+      },
+      function (cb) {
+        Trie.prove(trie, 'key1aa', function (err, prove) {
+          if (err) return cb(err)
+          Trie.verifyProof(trie.root, 'key1aa', prove, function (err, val) {
+            if (err) return cb(err)
+            st.equal(val.toString('utf8'), '01234')
+            cb()
+          })
+        })
+      }
+    ], function (err) {
+      st.end(err)
+    })
+  })
+})
+
 tape('secure tests', function (it) {
   let trie = new Trie()
   const jsonTests = require('./fixture/trietest_secureTrie.json').tests


### PR DESCRIPTION
`SecureTrie` hashes keys before `put` and `get`, however because it inherited `CheckpointTrie`'s `prove` and `verifyProof` methods (which doesn't hash keys), the methods didn't work because they couldn't find nodes in the trie. This PR fixes that and adds a simple test case which fails without the fix but passes afterwards.