### PR TITLE
_lookupNode callback to use standard error, response pattern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,14 +2,15 @@ package-lock.json
 node_modules
 dist/
 
-baseTrie.js
-checkpoint-interface.js
-index.js
-prioritizedTaskExecutor.js
-proof.js
-readStream.js
-secure-interface.js
-secure.js
-scratchReadStream.js
-trieNode.js
-util.js
+/baseTrie.js
+/checkpointTrie.js
+/db.js
+/index.js
+/prioritizedTaskExecutor.js
+/proof.js
+/readStream.js
+/scratch.js
+/scratchReadStream.js
+/secure.js
+/trieNode.js
+/util/

--- a/test/index.js
+++ b/test/index.js
@@ -12,7 +12,9 @@ tape('simple save and retrive', function (tester) {
 
     trie.get('test', function (err, value) {
       t.equal(value, null)
-      t.end(err)
+
+      t.notEqual(err, null)
+      t.end()
     })
   })
 

--- a/test/secure.js
+++ b/test/secure.js
@@ -2,7 +2,6 @@ const Trie = require('../src/secure.js')
 const async = require('async')
 const tape = require('tape')
 
-
 tape('SecureTrie', function (t) {
   const trie = new Trie()
   const k = Buffer.from('foo')


### PR DESCRIPTION
PR #82 broken into 2 pieces

This one doesn't deal with proofs. It just standardizes the callback pattern of `_lookupNode`