### PR TITLE
Org links and git hooks

### DIFF
--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -1,0 +1,9 @@
+# Contributing
+
+Great that you want to contribute to the `EthereumJS` [ecosystem](https://ethereumjs.readthedocs.io/en/latest/introduction.html). `EthereumJS` is managed by the Ethereum Foundation and largely driven by the wider community. Everyone is welcome to join the effort and help to improve on the libraries (see our [Code of Conduct](https://ethereumjs.readthedocs.io/en/latest/code_of_conduct.html) 🌷).
+
+We have written up some [Contribution Guidelines](https://ethereumjs.readthedocs.io/en/latest/contributing.html#how-to-start) to help you getting started.
+
+These include information on how we work with **Git** and how our **general workflow** and **technical setup** looks like (stuff like language, tooling, code quality and style).
+
+Happy Coding! 👾 😀 💻

--- a/README.md
+++ b/README.md
@@ -80,5 +80,11 @@ trie.createReadStream()
 - ["Understanding the ethereum trie"](https://easythereentropy.wordpress.com/2014/06/04/understanding-the-ethereum-trie/) blog post
 - ["Trie and Patricia Trie Overview"](https://www.youtube.com/watch?v=jXAHLqQthKw&t=26s) Video Talk on Youtube
 
+# EthereumJS
+
+See our organizational [documentation](https://ethereumjs.readthedocs.io) for an introduction to `EthereumJS` as well as information on current standards and best practices.
+
+If you want to join for work or do improvements on the libraries have a look at our [contribution guidelines](https://ethereumjs.readthedocs.io/en/latest/contributing.html).
+
 # LICENSE
 MPL-2.0

--- a/package.json
+++ b/package.json
@@ -15,6 +15,11 @@
     "build": "npm run babel && mkdir -p dist && browserify --s Trie index.js -o dist/trie.js -t [ babelify --presets [ @babel/preset-env ] ]",
     "build:docs": "documentation build ./src/** -f md --shallow ./src/index.js ./src/secure.js ./src/proof.js > ./docs/index.md --github --config documentation.yml --markdown-toc false"
   },
+  "husky": {
+    "hooks": {
+      "pre-push": "npm run lint"
+    }
+  },
   "author": {
     "name": "mjbecze",
     "email": "mjbecze@gmail.com"
@@ -52,6 +57,7 @@
     "browserify": "^13.0.0",
     "coveralls": "^2.11.6",
     "documentation": "^8.1.2",
+    "husky": "^2.1.0",
     "istanbul": "^0.4.1",
     "karma": "^1.7.1",
     "karma-browserify": "^5.0.0",


### PR DESCRIPTION
Organization wide application of GitHooks https://github.com/ethereumjs/ethereumjs-account/pull/46 and organizational docs linking https://github.com/ethereumjs/ethereumjs-account/pull/49.