### PR TITLE
Use module.exports syntax in util files

### DIFF
--- a/src/util/hex.js
+++ b/src/util/hex.js
@@ -4,7 +4,7 @@
  * @param {Array} Array of nibbles
  * @returns {Array} - returns buffer of encoded data
  **/
-export function addHexPrefix (key, terminator) {
+function addHexPrefix (key, terminator) {
   // odd
   if (key.length % 2) {
     key.unshift(1)
@@ -27,7 +27,7 @@ export function addHexPrefix (key, terminator) {
  * @param {Array} Array of nibbles
  * @private
  */
-export function removeHexPrefix (val) {
+function removeHexPrefix (val) {
   if (val[0] % 2) {
     val = val.slice(1)
   } else {
@@ -43,6 +43,12 @@ export function removeHexPrefix (val) {
  * @param {Array} key - an hexprefixed array of nibbles
  * @private
  */
-export function isTerminator (key) {
+function isTerminator (key) {
   return key[0] > 1
+}
+
+module.exports = {
+  addHexPrefix,
+  removeHexPrefix,
+  isTerminator
 }

--- a/src/util/nibbles.js
+++ b/src/util/nibbles.js
@@ -4,7 +4,7 @@
  * @param {Buffer| String} key
  * @private
  */
-export function stringToNibbles (key) {
+function stringToNibbles (key) {
   const bkey = new Buffer(key)
   let nibbles = []
 
@@ -24,7 +24,7 @@ export function stringToNibbles (key) {
  * @param {Array} Nibble array
  * @private
  */
-export function nibblesToBuffer (arr) {
+function nibblesToBuffer (arr) {
   let buf = new Buffer(arr.length / 2)
   for (let i = 0; i < buf.length; i++) {
     let q = i * 2
@@ -40,7 +40,7 @@ export function nibblesToBuffer (arr) {
  * @param {Array} nib2
  * @private
  */
-export function matchingNibbleLength (nib1, nib2) {
+function matchingNibbleLength (nib1, nib2) {
   let i = 0
   while (nib1[i] === nib2[i] && nib1.length > i) {
     i++
@@ -53,7 +53,14 @@ export function matchingNibbleLength (nib1, nib2) {
  * @param {Array} keyA
  * @param {Array} keyB
  */
-export function doKeysMatch (keyA, keyB) {
+function doKeysMatch (keyA, keyB) {
   const length = matchingNibbleLength(keyA, keyB)
   return length === keyA.length && length === keyB.length
+}
+
+module.exports = {
+  stringToNibbles,
+  nibblesToBuffer,
+  matchingNibbleLength,
+  doKeysMatch
 }


### PR DESCRIPTION
I remember facing some issues with the ES6 `export` syntax and it revolved around browsers. I suggest we use `module.exports` for now like the rest of the library. We can go back to the cleaner `export` syntax during the Typescript migration.