### PR TITLE
Refactor TrieNode, add levelup types

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "@ethereumjs/config-tsc": "^1.1.1",
     "@ethereumjs/config-tslint": "^1.1.1",
     "@types/bn.js": "^4.11.5",
+    "@types/levelup": "^3.1.1",
     "browserify": "^13.0.0",
     "coveralls": "^3.0.5",
     "husky": "^2.1.0",

--- a/src/baseTrie.ts
+++ b/src/baseTrie.ts
@@ -1,4 +1,3 @@
-import * as rlp from 'rlp'
 import { LevelUp } from 'levelup'
 import * as ethUtil from 'ethereumjs-util'
 import { DB, BatchDBOp, PutBatch } from './db'
@@ -690,7 +689,7 @@ export class Trie {
       } else {
         // the lastNode has to be a leaf if its not a branch. And a leaf's parent
         // if it has one must be a branch.
-        if (!parentNode || !(parentNode instanceof BranchNode)) {
+        if (!(parentNode instanceof BranchNode)) {
           return cb(new Error('Expected branch node'))
         }
         const lastNodeKey = lastNode.key

--- a/src/baseTrie.ts
+++ b/src/baseTrie.ts
@@ -1,13 +1,22 @@
 import * as rlp from 'rlp'
+import { LevelUp } from 'levelup'
 import * as ethUtil from 'ethereumjs-util'
 import { DB, BatchDBOp, PutBatch } from './db'
-import { TrieNode } from './trieNode'
 import { TrieReadStream as ReadStream } from './readStream'
 import { PrioritizedTaskExecutor } from './prioritizedTaskExecutor'
 import { callTogether } from './util/async'
 import { stringToNibbles, matchingNibbleLength, doKeysMatch } from './util/nibbles'
 import { ErrorCallback } from './types'
-import { LevelUp } from 'levelup'
+import {
+  TrieNode,
+  decodeNode,
+  decodeRawNode,
+  isRawNode,
+  BranchNode,
+  ExtensionNode,
+  LeafNode,
+  EmbeddedNode,
+} from './trieNode'
 const assert = require('assert')
 const async = require('async')
 const semaphore = require('semaphore')
@@ -219,14 +228,14 @@ export class Trie {
   }
 
   // retrieves a node from dbs by hash
-  _lookupNode(node: Buffer, cb: Function) {
-    if (TrieNode.isRawNode(node)) {
-      cb(null, new TrieNode(node))
+  _lookupNode(node: Buffer | Buffer[], cb: Function) {
+    if (isRawNode(node)) {
+      cb(null, decodeRawNode(node as Buffer[]))
     } else {
-      this.db.get(node, (err: Error, value: Buffer | null) => {
+      this.db.get(node as Buffer, (err: Error, value: Buffer | null) => {
         let node = null
         if (value) {
-          node = new TrieNode(rlp.decode(value))
+          node = decodeNode(value)
         } else {
           err = new Error('Missing node in DB')
         }
@@ -267,19 +276,16 @@ export class Trie {
       keyProgress: number[],
       walkController: any,
     ) {
-      const nodeKey = node.key || []
       const keyRemainder = targetKey.slice(matchingNibbleLength(keyProgress, targetKey))
-      const matchingLen = matchingNibbleLength(keyRemainder, nodeKey)
-
       stack.push(node)
 
-      if (node.type === 'branch') {
+      if (node instanceof BranchNode) {
         if (keyRemainder.length === 0) {
           walkController.return(null, node, [], stack)
           // we exhausted the key without finding a node
         } else {
           const branchIndex = keyRemainder[0]
-          const branchNode = node.getValue(branchIndex)
+          const branchNode = node.getBranch(branchIndex)
           if (!branchNode) {
             // there are no more nodes to find and we didn't find the key
             walkController.return(null, null, keyRemainder, stack)
@@ -288,16 +294,17 @@ export class Trie {
             walkController.only(branchIndex)
           }
         }
-      } else if (node.type === 'leaf') {
-        if (doKeysMatch(keyRemainder, nodeKey)) {
+      } else if (node instanceof LeafNode) {
+        if (doKeysMatch(keyRemainder, node.key)) {
           // keys match, return node with empty key
           walkController.return(null, node, [], stack)
         } else {
           // reached leaf but keys dont match
           walkController.return(null, null, keyRemainder, stack)
         }
-      } else if (node.type === 'extention') {
-        if (matchingLen !== nodeKey.length) {
+      } else if (node instanceof ExtensionNode) {
+        const matchingLen = matchingNibbleLength(keyRemainder, node.key)
+        if (matchingLen !== node.key.length) {
           // keys dont match, fail
           walkController.return(null, null, keyRemainder, stack)
         } else {
@@ -317,14 +324,11 @@ export class Trie {
       (nodeRef: Buffer, node: TrieNode, key: number[], walkController: any) => {
         let fullKey = key
 
-        if (node.key) {
+        if (node instanceof LeafNode) {
           fullKey = key.concat(node.key)
-        }
-
-        if (node.type === 'leaf') {
           // found leaf node!
           onFound(nodeRef, node, fullKey, walkController.next)
-        } else if (node.type === 'branch' && node.value) {
+        } else if (node instanceof BranchNode && node.value) {
           // found branch with value
           onFound(nodeRef, node, fullKey, walkController.next)
         } else {
@@ -344,7 +348,7 @@ export class Trie {
     this._walkTrie(
       this.root,
       (nodeRef: Buffer, node: TrieNode, key: number[], walkController: any) => {
-        if (TrieNode.isRawNode(nodeRef)) {
+        if (isRawNode(nodeRef)) {
           walkController.next()
         } else {
           onFound(nodeRef, node, key, walkController.next)
@@ -364,7 +368,13 @@ export class Trie {
    * @param {Array} stack -
    * @param {Function} cb - the callback
    */
-  _updateNode(k: Buffer, value: Buffer, keyRemainder: number[], stack: TrieNode[], cb: ErrorCallback) {
+  _updateNode(
+    k: Buffer,
+    value: Buffer,
+    keyRemainder: number[],
+    stack: TrieNode[],
+    cb: ErrorCallback,
+  ) {
     const toSave: BatchDBOp[] = []
     const lastNode = stack.pop()
     if (!lastNode) {
@@ -377,13 +387,13 @@ export class Trie {
     // Check if the last node is a leaf and the key matches to this
     let matchLeaf = false
 
-    if (lastNode.type === 'leaf') {
+    if (lastNode instanceof LeafNode) {
       let l = 0
 
       for (let i = 0; i < stack.length; i++) {
         const n = stack[i]
 
-        if (n.type === 'branch') {
+        if (n instanceof BranchNode) {
           l++
         } else {
           l += n.key.length
@@ -402,13 +412,13 @@ export class Trie {
       // just updating a found value
       lastNode.value = value
       stack.push(lastNode)
-    } else if (lastNode.type === 'branch') {
+    } else if (lastNode instanceof BranchNode) {
       stack.push(lastNode)
       if (keyRemainder.length !== 0) {
         // add an extention to a branch node
         keyRemainder.shift()
         // create a new leaf
-        const newLeaf = new TrieNode('leaf', keyRemainder, value)
+        const newLeaf = new LeafNode(keyRemainder, value)
         stack.push(newLeaf)
       } else {
         lastNode.value = value
@@ -417,12 +427,12 @@ export class Trie {
       // create a branch node
       const lastKey = lastNode.key
       const matchingLength = matchingNibbleLength(lastKey, keyRemainder)
-      const newBranchNode = new TrieNode('branch')
+      const newBranchNode = new BranchNode()
 
       // create a new extention node
       if (matchingLength !== 0) {
         const newKey = lastNode.key.slice(0, matchingLength)
-        const newExtNode = new TrieNode('extention', newKey, value)
+        const newExtNode = new ExtensionNode(newKey, value)
         stack.push(newExtNode)
         lastKey.splice(0, matchingLength)
         keyRemainder.splice(0, matchingLength)
@@ -433,15 +443,15 @@ export class Trie {
       if (lastKey.length !== 0) {
         const branchKey = lastKey.shift() as number
 
-        if (lastKey.length !== 0 || lastNode.type === 'leaf') {
+        if (lastKey.length !== 0 || lastNode instanceof LeafNode) {
           // shriking extention or leaf
           lastNode.key = lastKey
           const formatedNode = this._formatNode(lastNode, false, toSave)
-          newBranchNode.setValue(branchKey, formatedNode as Buffer)
+          newBranchNode.setBranch(branchKey, formatedNode as EmbeddedNode)
         } else {
           // remove extention or attaching
           this._formatNode(lastNode, false, toSave, true)
-          newBranchNode.setValue(branchKey, lastNode.value)
+          newBranchNode.setBranch(branchKey, lastNode.value)
         }
       } else {
         newBranchNode.value = lastNode.value
@@ -450,7 +460,7 @@ export class Trie {
       if (keyRemainder.length !== 0) {
         keyRemainder.shift()
         // add a leaf node to the new branch node
-        const newLeafNode = new TrieNode('leaf', keyRemainder, value)
+        const newLeafNode = new LeafNode(keyRemainder, value)
         stack.push(newLeafNode)
       } else {
         newBranchNode.value = value
@@ -513,7 +523,16 @@ export class Trie {
             return cb()
           }
 
-          const children = node.getChildren()
+          if (node instanceof LeafNode) {
+            return cb()
+          }
+
+          let children
+          if (node instanceof ExtensionNode) {
+            children = [[node.key, node.value]]
+          } else if (node instanceof BranchNode) {
+            children = node.getChildren().map(b => [[b[0]], b[1]])
+          }
           async.forEachOf(
             children,
             (childData: (Buffer | number[])[], index: number, cb: Function) => {
@@ -535,17 +554,20 @@ export class Trie {
           )
         },
         only: function(childIndex: number) {
-          const childRef = node.getValue(childIndex)
+          if (!(node instanceof BranchNode)) {
+            return cb(new Error('Expected branch node'))
+          }
+          const childRef = node.getBranch(childIndex)
           const childKey = key.slice()
           childKey.push(childIndex)
           const priority = childKey.length
           taskExecutor.execute(priority, (taskCallback: Function) => {
-            self._lookupNode(childRef, (e: Error, childNode: TrieNode) => {
+            self._lookupNode(childRef as Buffer, (e: Error, childNode: TrieNode) => {
               if (e) {
                 return cb(e, node)
               }
               taskCallback()
-              processNode(childRef, childNode, childKey, cb)
+              processNode(childRef as Buffer, childNode, childKey, cb)
             })
           })
         },
@@ -570,17 +592,17 @@ export class Trie {
     // update nodes
     while (stack.length) {
       const node = stack.pop() as TrieNode
-      if (node.type === 'leaf') {
+      if (node instanceof LeafNode) {
         key.splice(key.length - node.key.length)
-      } else if (node.type === 'extention') {
+      } else if (node instanceof ExtensionNode) {
         key.splice(key.length - node.key.length)
         if (lastRoot) {
           node.value = lastRoot
         }
-      } else if (node.type === 'branch') {
+      } else if (node instanceof BranchNode) {
         if (lastRoot) {
           const branchKey = key.pop()
-          node.setValue(branchKey!, lastRoot)
+          node.setBranch(branchKey!, lastRoot)
         }
       }
       lastRoot = this._formatNode(node, stack.length === 0, opStack) as Buffer
@@ -602,45 +624,40 @@ export class Trie {
       stack: TrieNode[],
     ) {
       // branchNode is the node ON the branch node not THE branch node
-      const branchNodeKey = branchNode.key
-      if (!parentNode || parentNode.type === 'branch') {
+      if (!parentNode || parentNode instanceof BranchNode) {
         // branch->?
         if (parentNode) {
           stack.push(parentNode)
         }
 
-        if (branchNode.type === 'branch') {
+        if (branchNode instanceof BranchNode) {
           // create an extention node
           // branch->extention->branch
-          const extentionNode = new TrieNode('extention', [branchKey], null)
+          // @ts-ignore
+          const extentionNode = new ExtensionNode([branchKey], null)
           stack.push(extentionNode)
           key.push(branchKey)
         } else {
+          const branchNodeKey = branchNode.key
           // branch key is an extention or a leaf
           // branch->(leaf or extention)
           branchNodeKey.unshift(branchKey)
-          branchNode.key = branchNodeKey
-
-          // hackery. This is equvilant to array.concat except we need keep the
-          // rerfance to the `key` that was passed in.
-          branchNodeKey.unshift(0)
-          branchNodeKey.unshift(key.length)
-          // TODO
-          // @ts-ignore
-          key.splice.apply(key, branchNodeKey)
+          branchNode.key = branchNodeKey.slice(0)
+          key = key.concat(branchNodeKey)
         }
         stack.push(branchNode)
       } else {
         // parent is a extention
         let parentKey = parentNode.key
 
-        if (branchNode.type === 'branch') {
+        if (branchNode instanceof BranchNode) {
           // ext->branch
           parentKey.push(branchKey)
           key.push(branchKey)
           parentNode.key = parentKey
           stack.push(parentNode)
         } else {
+          const branchNodeKey = branchNode.key
           // branch node is an leaf or extention and parent node is an exstention
           // add two keys together
           // dont push the parent node
@@ -668,33 +685,26 @@ export class Trie {
       this.root = this.EMPTY_TRIE_ROOT
       cb()
     } else {
-      if (lastNode.type === 'branch') {
-        // @ts-ignore
+      if (lastNode instanceof BranchNode) {
         lastNode.value = null
       } else {
         // the lastNode has to be a leaf if its not a branch. And a leaf's parent
         // if it has one must be a branch.
+        if (!parentNode || !(parentNode instanceof BranchNode)) {
+          return cb(new Error('Expected branch node'))
+        }
         const lastNodeKey = lastNode.key
         key.splice(key.length - lastNodeKey.length)
         // delete the value
         this._formatNode(lastNode, false, opStack, true)
-        // @ts-ignore
-        parentNode.setValue(key.pop() as number, null)
+        parentNode.setBranch(key.pop() as number, null)
         lastNode = parentNode
-        assert(lastNode)
         parentNode = stack.pop()
       }
 
       // nodes on the branch
-      const branchNodes: [number, Buffer][] = []
       // count the number of nodes on the branch
-      lastNode.raw.forEach((node, i) => {
-        const val = lastNode.getValue(i)
-
-        if (val) {
-          branchNodes.push([i, val])
-        }
-      })
+      const branchNodes: [number, EmbeddedNode][] = lastNode.getChildren()
 
       // if there is only one branch node left, collapse the branch node
       if (branchNodes.length === 1) {
@@ -724,7 +734,7 @@ export class Trie {
 
   // Creates the initial node from an empty tree
   _createInitialNode(key: Buffer, value: Buffer, cb: ErrorCallback) {
-    const newNode = new TrieNode('leaf', key, value)
+    const newNode = new LeafNode(stringToNibbles(key), value)
     this.root = newNode.hash()
     this._putNode(newNode, cb)
   }
@@ -736,7 +746,7 @@ export class Trie {
     topLevel: boolean,
     opStack: BatchDBOp[],
     remove: boolean = false,
-  ): Buffer | Buffer[] {
+  ): Buffer | (EmbeddedNode | null)[] {
     const rlpNode = node.serialize()
 
     if (rlpNode.length >= 32 || topLevel) {
@@ -751,7 +761,7 @@ export class Trie {
       return hashRoot
     }
 
-    return node.raw
+    return node.raw()
   }
 
   /**

--- a/src/checkpointTrie.ts
+++ b/src/checkpointTrie.ts
@@ -4,6 +4,7 @@ import { ScratchDB } from './scratch'
 import { callTogether } from './util/async'
 import { DB, BatchDBOp } from './db'
 import { TrieNode } from './trieNode'
+import { ErrorCallback } from './types'
 const async = require('async')
 const WriteStream = require('level-ws')
 
@@ -113,7 +114,7 @@ export class CheckpointTrie extends BaseTrie {
    * key/value db, disregarding checkpoints.
    * @deprecated
    */
-  putRaw(key: Buffer, value: Buffer, cb: Function) {
+  putRaw(key: Buffer, value: Buffer, cb: ErrorCallback) {
     this._mainDB.put(key, value, cb)
   }
 

--- a/src/checkpointTrie.ts
+++ b/src/checkpointTrie.ts
@@ -182,6 +182,6 @@ export class CheckpointTrie extends BaseTrie {
       return hashRoot
     }
 
-    return node.raw
+    return node.raw()
   }
 }

--- a/src/secure.ts
+++ b/src/secure.ts
@@ -1,5 +1,6 @@
 import { keccak256 } from 'ethereumjs-util'
 import { CheckpointTrie } from './checkpointTrie'
+import { ErrorCallback } from './types'
 
 /**
  * You can create a secure Trie where the keys are automatically hashed
@@ -39,7 +40,7 @@ export class SecureTrie extends CheckpointTrie {
    * For a falsey value, use the original key
    * to avoid double hashing the key.
    */
-  put(key: Buffer, val: Buffer, cb: Function) {
+  put(key: Buffer, val: Buffer, cb: ErrorCallback) {
     if (!val) {
       this.del(key, cb)
     } else {
@@ -48,7 +49,7 @@ export class SecureTrie extends CheckpointTrie {
     }
   }
 
-  del(key: Buffer, cb: Function) {
+  del(key: Buffer, cb: ErrorCallback) {
     const hash = keccak256(key)
     super.del(hash, cb)
   }

--- a/src/trieNode.ts
+++ b/src/trieNode.ts
@@ -1,181 +1,197 @@
 import * as rlp from 'rlp'
-import { keccak256 } from 'ethereumjs-util'
+import { keccak256, KECCAK256_RLP } from 'ethereumjs-util'
 import { stringToNibbles, nibblesToBuffer } from './util/nibbles'
 import { isTerminator, addHexPrefix, removeHexPrefix } from './util/hex'
 
-enum NodeType {
-  Leaf = 'leaf',
-  Branch = 'branch',
-  Extension = 'extention', // FIXME
-  Unknown = 'unknown', // TODO
+export type TrieNode = BranchNode | ExtensionNode | LeafNode
+export type Nibbles = number[]
+// Branch and extension nodes might store
+// hash to next node, or embed it if its len < 32
+export type EmbeddedNode = Buffer | Buffer[]
+
+export function decodeNode(raw: Buffer): TrieNode {
+  const des = rlp.decode(raw)
+  if (!Array.isArray(des)) {
+    throw new Error('Invalid node')
+  }
+  return decodeRawNode(des)
 }
 
-export class TrieNode {
-  raw: Buffer[]
-  type: NodeType
-
-  constructor(type: any, key?: any, value?: any) {
-    if (Array.isArray(type)) {
-      this.raw = type
-      this.type = TrieNode.getNodeType(type)
-    } else {
-      this.type = type
-      if (type === 'branch') {
-        var values = key
-        // @ts-ignore
-        this.raw = Array.apply(null, Array(17))
-        if (values) {
-          values.forEach(function(this: any, keyVal: any) {
-            this.set.apply(this, keyVal)
-          })
-        }
-      } else {
-        this.raw = Array(2)
-        this.setValue(value)
-        this.setKey(key)
-      }
+export function decodeRawNode(raw: Buffer[]): TrieNode {
+  if (raw.length === 17) {
+    return BranchNode.fromArray(raw)
+  } else if (raw.length === 2) {
+    const nibbles = stringToNibbles(raw[0])
+    if (isTerminator(nibbles)) {
+      return new LeafNode(LeafNode.decodeKey(nibbles), raw[1])
     }
+    return new ExtensionNode(ExtensionNode.decodeKey(nibbles), raw[1])
+  } else {
+    throw new Error('Invalid node')
+  }
+}
+
+export function isRawNode(n: any): boolean {
+  return Array.isArray(n) && !Buffer.isBuffer(n)
+}
+
+export class BranchNode {
+  _branches: (EmbeddedNode | null)[]
+  _value: Buffer | null
+
+  constructor() {
+    this._branches = new Array(16).fill(null)
+    this._value = null
   }
 
-  /**
-   * Determines the node type.
-   * @private
-   * @returns {String} - the node type
-   *   - leaf - if the node is a leaf
-   *   - branch - if the node is a branch
-   *   - extention - if the node is an extention
-   *   - unknown - if something else got borked
-   */
-  static getNodeType(node: Buffer[]): NodeType {
-    if (node.length === 17) {
-      return NodeType.Branch
-    } else if (node.length === 2) {
-      var key = stringToNibbles(node[0])
-      if (isTerminator(key)) {
-        return NodeType.Leaf
-      }
-
-      return NodeType.Extension
-    }
-    throw new Error('invalid node type')
+  static fromArray(arr: Buffer[]): BranchNode {
+    const node = new BranchNode()
+    node._branches = arr.slice(0, 16)
+    node._value = arr[16]
+    return node
   }
 
-  static isRawNode(node: any): boolean {
-    return Array.isArray(node) && !Buffer.isBuffer(node)
+  get value(): Buffer | null {
+    return this._value && this._value.length > 0 ? this._value : null
   }
 
-  get value(): Buffer {
-    return this.getValue()
+  set value(v: Buffer | null) {
+    this._value = v
   }
 
-  set value(v) {
-    this.setValue(v)
+  setBranch(i: number, v: EmbeddedNode | null) {
+    this._branches[i] = v
   }
 
-  get key(): number[] {
-    return this.getKey()
-  }
-
-  set key(k) {
-    this.setKey(k)
-  }
-
-  // TODO: refactor
-  setValue(key: Buffer | number, value?: Buffer) {
-    if (this.type !== 'branch') {
-      this.raw[1] = key as Buffer
-    } else {
-      if (arguments.length === 1) {
-        value = key as Buffer
-        key = 16
-      }
-      this.raw[key as number] = value as Buffer
-    }
-  }
-
-  // @ts-ignore
-  getValue(key?: number): Buffer {
-    if (this.type === 'branch') {
-      if (arguments.length === 0) {
-        key = 16
-      }
-
-      var val = this.raw[key as number]
-      if (val !== null && val !== undefined && val.length !== 0) {
-        return val
-      }
-    } else {
-      return this.raw[1]
-    }
-  }
-
-  setKey(key: Buffer | number[]) {
-    if (this.type !== 'branch') {
-      if (Buffer.isBuffer(key)) {
-        key = stringToNibbles(key)
-      } else {
-        key = key.slice(0) // copy the key
-      }
-
-      key = addHexPrefix(key, this.type === 'leaf')
-      this.raw[0] = nibblesToBuffer(key)
-    }
-  }
-
-  // @ts-ignore
-  getKey(): number[] {
-    if (this.type !== 'branch') {
-      let key = this.raw[0]
-      let nibbles = removeHexPrefix(stringToNibbles(key))
-      return nibbles
-    }
+  raw(): (EmbeddedNode | null)[] {
+    return [...this._branches, this._value]
   }
 
   serialize(): Buffer {
-    return rlp.encode(this.raw)
+    return rlp.encode(this.raw())
   }
 
   hash(): Buffer {
     return keccak256(this.serialize())
   }
 
-  toString(): string {
-    // @ts-ignore
-    let out = NodeType[this.type]
-    out += ': ['
-    this.raw.forEach(function(el) {
-      if (Buffer.isBuffer(el)) {
-        out += el.toString('hex') + ', '
-      } else if (el) {
-        out += 'object, '
-      } else {
-        out += 'empty, '
-      }
-    })
-    out = out.slice(0, -2)
-    out += ']'
-    return out
+  getBranch(i: number) {
+    const b = this._branches[i]
+    if (b !== null && b.length > 0) {
+      return b
+    } else {
+      return null
+    }
   }
 
-  getChildren(): (Buffer | number[])[][] {
-    var children = []
-    switch (this.type) {
-      case 'leaf':
-        // no children
-        break
-      case 'extention':
-        // one child
-        children.push([this.key, this.getValue()])
-        break
-      case 'branch':
-        for (let index = 0, end = 16; index < end; index++) {
-          const value = this.getValue(index)
-          if (value) {
-            children.push([[index], value])
-          }
-        }
-        break
+  getChildren(): [number, EmbeddedNode][] {
+    const children: [number, EmbeddedNode][] = []
+    for (let i = 0; i < 16; i++) {
+      let b = this._branches[i]
+      if (b !== null && b.length > 0) {
+        children.push([i, b])
+      }
     }
     return children
+  }
+}
+
+export class ExtensionNode {
+  _nibbles: Nibbles
+  _value: Buffer
+
+  constructor(nibbles: Nibbles, value: Buffer) {
+    this._nibbles = nibbles
+    this._value = value
+  }
+
+  static encodeKey(key: Nibbles): Nibbles {
+    return addHexPrefix(key, false)
+  }
+
+  static decodeKey(key: Nibbles): Nibbles {
+    return removeHexPrefix(key)
+  }
+
+  get key(): Nibbles {
+    return this._nibbles.slice(0)
+  }
+
+  set key(k: Nibbles) {
+    this._nibbles = k
+  }
+
+  get value(): Buffer {
+    return this._value
+  }
+
+  set value(v: Buffer) {
+    this._value = v
+  }
+
+  encodedKey(): Nibbles {
+    return ExtensionNode.encodeKey(this._nibbles.slice(0))
+  }
+
+  raw(): [Buffer, Buffer] {
+    return [nibblesToBuffer(this.encodedKey()), this._value]
+  }
+
+  serialize(): Buffer {
+    return rlp.encode(this.raw())
+  }
+
+  hash(): Buffer {
+    return keccak256(this.serialize())
+  }
+}
+
+export class LeafNode {
+  _nibbles: Nibbles
+  _value: Buffer
+
+  constructor(nibbles: Nibbles, value: Buffer) {
+    this._nibbles = nibbles
+    this._value = value
+  }
+
+  static encodeKey(key: Nibbles): Nibbles {
+    return addHexPrefix(key, true)
+  }
+
+  static decodeKey(encodedKey: Nibbles): Nibbles {
+    return removeHexPrefix(encodedKey)
+  }
+
+  get key(): Nibbles {
+    return this._nibbles.slice(0)
+  }
+
+  set key(k: Nibbles) {
+    this._nibbles = k
+  }
+
+  get value(): Buffer {
+    return this._value
+  }
+
+  set value(v: Buffer) {
+    this._value = v
+  }
+
+  encodedKey(): Nibbles {
+    return LeafNode.encodeKey(this._nibbles.slice(0))
+  }
+
+  raw(): [Buffer, Buffer] {
+    return [nibblesToBuffer(this.encodedKey()), this._value]
+  }
+
+  serialize(): Buffer {
+    return rlp.encode(this.raw())
+  }
+
+  hash(): Buffer {
+    return keccak256(this.serialize())
   }
 }

--- a/src/trieNode.ts
+++ b/src/trieNode.ts
@@ -1,5 +1,5 @@
 import * as rlp from 'rlp'
-import { keccak256, KECCAK256_RLP } from 'ethereumjs-util'
+import { keccak256 } from 'ethereumjs-util'
 import { stringToNibbles, nibblesToBuffer } from './util/nibbles'
 import { isTerminator, addHexPrefix, removeHexPrefix } from './util/hex'
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,1 @@
+export type ErrorCallback = (err?: Error) => void


### PR DESCRIPTION
On a high-level this PR:

- Adds typedefs for leveldb
- Breaks `TrieNode` into 3 classes `BranchNode`, `ExtensionNode` and `LeafNode`. It also makes the necessary modifications in `BaseTrie` to make it work with this new structure.

I'm still not fully sure about the details of the new types, specially around `EmbeddedNode`. That might have to change.

The way some of the internal methods modify nodes is very prone to errors (I had to debug a really nasty bug), due to arrays being mutable references.

I think after this I will try to promisify some parts and make the code a bit flatter so it's easier to work with.

Update: Oh and I tested it against ethereumjs-vm, tests pass.