### PR TITLE
Fix typos

### DIFF
--- a/src/baseTrie.ts
+++ b/src/baseTrie.ts
@@ -726,7 +726,7 @@ export class Trie {
    * @returns {Promise}
    */
   async batch(ops: BatchDBOp[]): Promise<void> {
-    for await (const op of ops) {
+    for (const op of ops) {
       if (op.type === 'put') {
         if (!op.value) {
           throw new Error('Invalid batch db operation')

--- a/test/db.spec.ts
+++ b/test/db.spec.ts
@@ -14,7 +14,7 @@ tape('DB basic functionality', (t) => {
     st.end()
   })
 
-  t.test('dels value', async (st) => {
+  t.test('deletes value', async (st) => {
     await db.del(k)
     const res = await db.get(k)
     st.notOk(res)

--- a/test/encoding.spec.ts
+++ b/test/encoding.spec.ts
@@ -6,7 +6,7 @@ const trie = new CheckpointTrie()
 const trie2 = new CheckpointTrie()
 const hex = 'FF44A3B3'
 
-tape('encoding hexprefixes', async function (t) {
+tape('encoding hex prefixes', async function (t) {
   await trie.put(Buffer.from(hex, 'hex'), Buffer.from('test'))
   await trie2.put(toBuffer(`0x${hex}`), Buffer.from('test'))
   t.equal(trie.root.toString('hex'), trie2.root.toString('hex'))

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -3,10 +3,10 @@ import * as rlp from 'rlp'
 import { KECCAK256_NULL } from 'ethereumjs-util'
 import { CheckpointTrie } from '../src'
 
-tape('simple save and retrive', function (tester) {
+tape('simple save and retrieve', function (tester) {
   const it = tester.test
 
-  it('should not crash if given a non-existant root', async function (t) {
+  it('should not crash if given a non-existent root', async function (t) {
     const root = Buffer.from(
       '3f4399b08efe68945c1cf90ffe85bbe3ce978959da753f9e649f034015b8817d',
       'hex',
@@ -90,13 +90,13 @@ tape('simple save and retrive', function (tester) {
       t.end()
     })
 
-    it('should retreive a longer value', async function (t) {
+    it('should retrieve a longer value', async function (t) {
       const value = await trie.get(Buffer.from('done'))
       t.equal(value!.toString(), longString)
       t.end()
     })
 
-    it('should when being modiefied delete the old value', async function (t) {
+    it('should when being modified delete the old value', async function (t) {
       await trie.put(Buffer.from('done'), Buffer.from('test'))
       t.end()
     })
@@ -217,10 +217,10 @@ tape('it should create the genesis state root from ethereum', function (tester) 
   const v = Buffer.from('1e12515ce3e0f817a4ddef9ca55788a1d66bd2df', 'hex')
   const a = Buffer.from('1a26338f0d905e295fccb71fa9ea849ffa12aaf4', 'hex')
 
-  let stateRoot = Buffer.alloc(32)
+  const stateRoot = Buffer.alloc(32)
   stateRoot.fill(0)
 
-  let startAmount = Buffer.alloc(26)
+  const startAmount = Buffer.alloc(26)
   startAmount.fill(0)
   startAmount[0] = 1
 

--- a/test/official.spec.ts
+++ b/test/official.spec.ts
@@ -1,14 +1,14 @@
 import * as tape from 'tape'
 import { CheckpointTrie } from '../src'
 
-tape('offical tests', async function (t) {
+tape('official tests', async function (t) {
   const jsonTests = require('./fixtures/trietest.json').tests
   const testNames = Object.keys(jsonTests)
   let trie = new CheckpointTrie()
 
-  for await (const testName of testNames) {
-    let inputs = jsonTests[testName].in
-    let expect = jsonTests[testName].root
+  for (const testName of testNames) {
+    const inputs = jsonTests[testName].in
+    const expect = jsonTests[testName].root
     for (const input of inputs) {
       for (let i = 0; i < 2; i++) {
         if (input[i] && input[i].slice(0, 2) === '0x') {
@@ -25,15 +25,15 @@ tape('offical tests', async function (t) {
   t.end()
 })
 
-tape('offical tests any order', async function (t) {
+tape('official tests any order', async function (t) {
   const jsonTests = require('./fixtures/trieanyorder.json').tests
   const testNames = Object.keys(jsonTests)
   let trie = new CheckpointTrie()
-  for await (const testName of testNames) {
+  for (const testName of testNames) {
     const test = jsonTests[testName]
     const keys = Object.keys(test.in)
     let key: any
-    for await (key of keys) {
+    for (key of keys) {
       let val = test.in[key]
 
       if (key.slice(0, 2) === '0x') {

--- a/test/prioritizedTaskExecutor.spec.ts
+++ b/test/prioritizedTaskExecutor.spec.ts
@@ -4,9 +4,9 @@ import { PrioritizedTaskExecutor } from '../src/prioritizedTaskExecutor'
 const taskExecutor = new PrioritizedTaskExecutor(2)
 
 tape('prioritized task executor test', function (t) {
-  let tasks = [1, 2, 3, 4]
-  let callbacks = [] as any
-  let executionOrder = [] as any
+  const tasks = [1, 2, 3, 4]
+  const callbacks = [] as any
+  const executionOrder = [] as any
   tasks.forEach(function (task) {
     taskExecutor.execute(task, function (cb: Function) {
       executionOrder.push(task)
@@ -18,7 +18,7 @@ tape('prioritized task executor test', function (t) {
     callback()
   })
 
-  let expectedExecutionOrder = [1, 2, 4, 3]
+  const expectedExecutionOrder = [1, 2, 4, 3]
   t.deepEqual(executionOrder, expectedExecutionOrder)
   t.end()
 })

--- a/test/secure.spec.ts
+++ b/test/secure.spec.ts
@@ -37,7 +37,7 @@ tape('SecureTrie', function (t) {
     const jsonTests = require('./fixtures/trietest_secureTrie.json').tests
 
     it.test('empty values', async function (t) {
-      for await (const row of jsonTests.emptyValues.in) {
+      for (const row of jsonTests.emptyValues.in) {
         const val = row[1] ? Buffer.from(row[1]) : ((null as unknown) as Buffer)
         await trie.put(Buffer.from(row[0]), val)
       }
@@ -47,7 +47,7 @@ tape('SecureTrie', function (t) {
 
     it.test('branchingTests', async function (t) {
       trie = new SecureTrie()
-      for await (const row of jsonTests.branchingTests.in) {
+      for (const row of jsonTests.branchingTests.in) {
         const val = row[1] ? Buffer.from(row[1]) : ((null as unknown) as Buffer)
         await trie.put(Buffer.from(row[0]), val)
       }
@@ -56,7 +56,7 @@ tape('SecureTrie', function (t) {
     })
 
     it.test('jeff', async function (t) {
-      for await (const row of jsonTests.jeff.in) {
+      for (const row of jsonTests.jeff.in) {
         let val = row[1]
         if (val) {
           val = Buffer.from(row[1].slice(2), 'hex')

--- a/test/stream.spec.ts
+++ b/test/stream.spec.ts
@@ -92,8 +92,8 @@ tape('kv stream test', function (tester) {
     },
   ] as BatchDBOp[]
 
-  let valObj = {} as any
-  for (let op of ops) {
+  const valObj = {} as any
+  for (const op of ops) {
     if (op.type === 'put') {
       valObj[op.key.toString()] = op.value.toString()
     }
@@ -113,7 +113,7 @@ tape('kv stream test', function (tester) {
       delete valObj[key]
     })
     stream.on('end', () => {
-      let keys = Object.keys(valObj)
+      const keys = Object.keys(valObj)
       t.equal(keys.length, 0)
       t.end()
     })
@@ -178,7 +178,7 @@ tape('db stream test', function (tester) {
       delete expectedNodes[key]
     })
     stream.on('end', () => {
-      let keys = Object.keys(expectedNodes)
+      const keys = Object.keys(expectedNodes)
       t.equal(keys.length, 0)
       t.end()
     })


### PR DESCRIPTION
This PR:

1. Fixes some test suite typos and `let`->`const` conversions found in EthWork's [sync-related work](https://github.com/ethereumjs/merkle-patricia-tree/compare/master...EthWorks:remove-async) - thanks guys!
1. Removes unneeded uses of `for await` when iterators are sync.