### PR TITLE
Create dual ES5 and ES2017 builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 package-lock.json
 node_modules
-dist/
+dist
+dist.browser
 .nyc_output
 coverage

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,6 +2,7 @@ node_modules
 .vscode
 package.json
 dist
+dist.browser
 .nyc_output
 *.json
 docs

--- a/package.json
+++ b/package.json
@@ -5,14 +5,16 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
-    "dist/**/*"
+    "dist",
+    "dist.browser"
   ],
+  "browser": "dist.browser/index.js",
   "scripts": {
     "benchmarks": "npm run build && ts-node benchmarks/index.ts",
-    "build": "ethereumjs-config-build",
+    "build": "tsc -p tsconfig.json && tsc -p tsconfig.browser.json",
     "prepublishOnly": "npm run test && npm run build",
     "coverage": "nyc --reporter=lcov npm run test:node",
-    "docs:build": "npx typedoc",
+    "docs:build": "typedoc",
     "lint": "ethereumjs-config-lint",
     "lint:fix": "ethereumjs-config-lint-fix",
     "format": "ethereumjs-config-format",
@@ -21,7 +23,7 @@
     "tsc": "ethereumjs-config-tsc",
     "test": "npm run test:node && npm run test:browser",
     "test:browser": "npm run build && karma start karma.conf.js",
-    "test:node": "npm run build && tape -r ts-node/register test/*.ts | tap-prettify -"
+    "test:node": "npm run build && tape -r ts-node/register test/*.ts"
   },
   "husky": {
     "hooks": {
@@ -70,7 +72,6 @@
     "karma-typescript": "^5.0.1",
     "nyc": "^15.0.0",
     "prettier": "^2.0.2",
-    "tap-prettify": "^0.0.2",
     "tape": "^4.13.2",
     "ts-node": "^8.8.1",
     "tslint": "^5.18.0",

--- a/tsconfig.browser.json
+++ b/tsconfig.browser.json
@@ -1,0 +1,9 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+      "outDir": "./dist.browser",
+    },
+    "target": "es5",
+    "lib": ["dom", "es5"]
+}
+  

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,8 @@
 {
   "extends": "@ethereumjs/config-tsc",
+  "compilerOptions": {
+    "outDir": "./dist"
+  },
   "include": ["src/**/*.ts"],
+  "target": "ES2017"
 }

--- a/tsconfig.prod.json
+++ b/tsconfig.prod.json
@@ -1,7 +1,0 @@
-{
-  "extends": "@ethereumjs/config-tsc",
-  "compilerOptions": {
-    "outDir": "./dist"
-  },
-  "include": ["src/**/*.ts"]
-}


### PR DESCRIPTION
@sz-piotr and @msieczko suggested to use a ES2017 build for the performance benefit of not using ts generators for async code.

@alcuadrado highlighted the importance of maintaining browser support and suggested using the [`browser`](https://docs.npmjs.com/files/package.json#browser) field in `package.json`.

This PR makes `dist` a ES2017 build and adds an additional build at `dist.browser` for ES5 (as inspired by [this post](https://medium.com/collaborne-engineering/typescript-create-library-for-nodejs-and-browser-fece291d517f)).