### PR TITLE
Rename Trie.prove to Trie.createProof

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ test()
 
 See the [docs](https://github.com/ethereumjs/merkle-patricia-tree/tree/master/docs) for the latest Promise-based method signatures.
 
+#### Trie.prove renamed to Trie.createProof
+
+To clarify the method's purpose `Trie.prove` has been renamed to `Trie.createProof`. `Trie.prove` has been deprecated but will remain as an alias for `Trie.createProof` until removed.
+
 #### Trie raw methods
 
 `getRaw`, `putRaw` and `delRaw` were deprecated in `v3.0.0` and have been removed from this release. Instead, please use `trie.db.get`, `trie.db.put`, and `trie.db.del`. If using a `SecureTrie` or `CheckpointTrie`, use `trie._maindb` to override the checkpointing mechanism and interact directly with the db.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ To clarify the method's purpose `Trie.prove` has been renamed to `Trie.createPro
 - Upgrade ethereumjs-util to 7.0.0 / Upgrade level-mem to 5.0.1 ([#116](https://github.com/ethereumjs/merkle-patricia-tree/pull/116))
 - Create dual ES5 and ES2017 builds ([#117](https://github.com/ethereumjs/merkle-patricia-tree/pull/117))
 - Include checkpoints by default in SecureTrie.copy ([#119](https://github.com/ethereumjs/merkle-patricia-tree/pull/119))
+- Rename Trie.prove to Trie.createProof ([#122](https://github.com/ethereumjs/merkle-patricia-tree/pull/122))
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 [![js-standard-style](https://cdn.rawgit.com/feross/standard/master/badge.svg)](https://github.com/feross/standard)
 
-This is an implementation of the modified merkle patricia tree as specified in the [Ethereum's Yellow Paper](http://gavwood.com/Paper.pdf):
+This is an implementation of the modified merkle patricia tree as specified in the [Ethereum Yellow Paper](http://gavwood.com/Paper.pdf):
 
 > The modified Merkle Patricia tree (trie) provides a persistent data structure to map between arbitrary-length binary data (byte arrays). It is defined in terms of a mutable data structure to map between 256-bit binary fragments and arbitrary-length binary data. The core of the trie, and its sole requirement in terms of the protocol specification is to provide a single 32-byte value that identifies a given set of key-value pairs.
 
@@ -42,10 +42,13 @@ test()
 ## Merkle Proofs
 
 ```typescript
+const trie = new Trie()
+
 async function test() {
-  const prove = await Trie.prove(trie, Buffer.from('test'))
-  const value = await Trie.verifyProof(trie.root, Buffer.from('test'), prove)
-  console.log(value.toString())
+  await trie.put(Buffer.from('test'), Buffer.from('one'))
+  const proof = await Trie.createProof(trie, Buffer.from('test'))
+  const value = await Trie.verifyProof(trie.root, Buffer.from('test'), proof)
+  console.log(value.toString()) // 'one'
 }
 
 test()

--- a/docs/classes/_basetrie_.trie.md
+++ b/docs/classes/_basetrie_.trie.md
@@ -38,13 +38,13 @@ If the db is `null` or left undefined, then the trie will be stored in memory vi
 
 ### Methods
 
-* [_createInitialNode](_basetrie_.trie.md#_createinitialnode)
-* [_deleteNode](_basetrie_.trie.md#_deletenode)
+* [_createInitialNode](_basetrie_.trie.md#private-_createinitialnode)
+* [_deleteNode](_basetrie_.trie.md#private-_deletenode)
 * [_findDbNodes](_basetrie_.trie.md#_finddbnodes)
-* [_findValueNodes](_basetrie_.trie.md#_findvaluenodes)
+* [_findValueNodes](_basetrie_.trie.md#private-_findvaluenodes)
 * [_formatNode](_basetrie_.trie.md#private-_formatnode)
-* [_lookupNode](_basetrie_.trie.md#_lookupnode)
-* [_putNode](_basetrie_.trie.md#_putnode)
+* [_lookupNode](_basetrie_.trie.md#private-_lookupnode)
+* [_putNode](_basetrie_.trie.md#private-_putnode)
 * [_saveStack](_basetrie_.trie.md#private-_savestack)
 * [_updateNode](_basetrie_.trie.md#private-_updatenode)
 * [_walkTrie](_basetrie_.trie.md#private-_walktrie)
@@ -57,6 +57,7 @@ If the db is `null` or left undefined, then the trie will be stored in memory vi
 * [get](_basetrie_.trie.md#get)
 * [put](_basetrie_.trie.md#put)
 * [setRoot](_basetrie_.trie.md#setroot)
+* [createProof](_basetrie_.trie.md#static-createproof)
 * [fromProof](_basetrie_.trie.md#static-fromproof)
 * [prove](_basetrie_.trie.md#static-prove)
 * [verifyProof](_basetrie_.trie.md#static-verifyproof)
@@ -67,7 +68,7 @@ If the db is `null` or left undefined, then the trie will be stored in memory vi
 
 \+ **new Trie**(`db?`: LevelUp | null, `root?`: Buffer): *[Trie](_basetrie_.trie.md)*
 
-*Defined in [baseTrie.ts:43](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L43)*
+*Defined in [baseTrie.ts:45](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L45)*
 
 **Parameters:**
 
@@ -84,7 +85,7 @@ Name | Type |
 
 • **EMPTY_TRIE_ROOT**: *Buffer*
 
-*Defined in [baseTrie.ts:40](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L40)*
+*Defined in [baseTrie.ts:42](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L42)*
 
 ___
 
@@ -92,7 +93,7 @@ ___
 
 • **db**: *DB*
 
-*Defined in [baseTrie.ts:41](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L41)*
+*Defined in [baseTrie.ts:43](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L43)*
 
 ## Accessors
 
@@ -100,13 +101,13 @@ ___
 
 • **get root**(): *Buffer*
 
-*Defined in [baseTrie.ts:101](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L101)*
+*Defined in [baseTrie.ts:127](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L127)*
 
 **Returns:** *Buffer*
 
 • **set root**(`value`: Buffer): *void*
 
-*Defined in [baseTrie.ts:97](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L97)*
+*Defined in [baseTrie.ts:123](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L123)*
 
 **Parameters:**
 
@@ -118,11 +119,13 @@ Name | Type |
 
 ## Methods
 
-###  _createInitialNode
+### `Private` _createInitialNode
 
 ▸ **_createInitialNode**(`key`: Buffer, `value`: Buffer): *Promise‹void›*
 
-*Defined in [baseTrie.ts:659](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L659)*
+*Defined in [baseTrie.ts:683](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L683)*
+
+Creates the initial node from an empty tree.
 
 **Parameters:**
 
@@ -135,11 +138,13 @@ Name | Type |
 
 ___
 
-###  _deleteNode
+### `Private` _deleteNode
 
 ▸ **_deleteNode**(`k`: Buffer, `stack`: TrieNode[]): *Promise‹void›*
 
-*Defined in [baseTrie.ts:537](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L537)*
+*Defined in [baseTrie.ts:558](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L558)*
+
+Deletes a node.
 
 **Parameters:**
 
@@ -156,7 +161,7 @@ ___
 
 ▸ **_findDbNodes**(`onFound`: FoundNode): *Promise‹void›*
 
-*Defined in [baseTrie.ts:280](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L280)*
+*Defined in [baseTrie.ts:302](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L302)*
 
 **Parameters:**
 
@@ -168,11 +173,13 @@ Name | Type |
 
 ___
 
-###  _findValueNodes
+### `Private` _findValueNodes
 
 ▸ **_findValueNodes**(`onFound`: FoundNode): *Promise‹void›*
 
-*Defined in [baseTrie.ts:258](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L258)*
+*Defined in [baseTrie.ts:280](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L280)*
+
+Finds all nodes that store k,v values.
 
 **Parameters:**
 
@@ -188,32 +195,32 @@ ___
 
 ▸ **_formatNode**(`node`: TrieNode, `topLevel`: boolean, `opStack`: BatchDBOp[], `remove`: boolean): *Buffer | null | Buffer‹› | Buffer‹›[][]*
 
-*Defined in [baseTrie.ts:675](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L675)*
+*Defined in [baseTrie.ts:698](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L698)*
 
-Formats node to be saved by levelup.batch.
-
-**`method`** _formatNode
+Formats node to be saved by `levelup.batch`.
 
 **Parameters:**
 
 Name | Type | Default | Description |
 ------ | ------ | ------ | ------ |
-`node` | TrieNode | - | the node to format |
-`topLevel` | boolean | - | if the node is at the top level |
-`opStack` | BatchDBOp[] | - | the opStack to push the node's data |
-`remove` | boolean | false | whether to remove the node (only used for CheckpointTrie) |
+`node` | TrieNode | - | the node to format. |
+`topLevel` | boolean | - | if the node is at the top level. |
+`opStack` | BatchDBOp[] | - | the opStack to push the node's data. |
+`remove` | boolean | false | whether to remove the node (only used for CheckpointTrie). |
 
 **Returns:** *Buffer | null | Buffer‹› | Buffer‹›[][]*
 
-- the node's hash used as the key or the rawNode
+The node's hash used as the key or the rawNode.
 
 ___
 
-###  _lookupNode
+### `Private` _lookupNode
 
 ▸ **_lookupNode**(`node`: Buffer | Buffer[]): *Promise‹TrieNode | null›*
 
-*Defined in [baseTrie.ts:173](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L173)*
+*Defined in [baseTrie.ts:194](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L194)*
+
+Retrieves a node from db by hash.
 
 **Parameters:**
 
@@ -225,11 +232,13 @@ Name | Type |
 
 ___
 
-###  _putNode
+### `Private` _putNode
 
 ▸ **_putNode**(`node`: TrieNode): *Promise‹void›*
 
-*Defined in [baseTrie.ts:191](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L191)*
+*Defined in [baseTrie.ts:215](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L215)*
+
+Writes a single node to db.
 
 **Parameters:**
 
@@ -245,11 +254,9 @@ ___
 
 ▸ **_saveStack**(`key`: Nibbles, `stack`: TrieNode[], `opStack`: BatchDBOp[]): *Promise‹void›*
 
-*Defined in [baseTrie.ts:508](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L508)*
+*Defined in [baseTrie.ts:525](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L525)*
 
-saves a stack
-
-**`method`** _saveStack
+Saves a stack.
 
 **Parameters:**
 
@@ -257,7 +264,7 @@ Name | Type | Description |
 ------ | ------ | ------ |
 `key` | Nibbles | the key. Should follow the stack |
 `stack` | TrieNode[] | a stack of nodes to the value given by the key |
-`opStack` | BatchDBOp[] | a stack of levelup operations to commit at the end of this funciton |
+`opStack` | BatchDBOp[] | a stack of levelup operations to commit at the end of this funciton  |
 
 **Returns:** *Promise‹void›*
 
@@ -267,20 +274,18 @@ ___
 
 ▸ **_updateNode**(`k`: Buffer, `value`: Buffer, `keyRemainder`: Nibbles, `stack`: TrieNode[]): *Promise‹void›*
 
-*Defined in [baseTrie.ts:300](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L300)*
+*Defined in [baseTrie.ts:320](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L320)*
 
-Updates a node
-
-**`method`** _updateNode
+Updates a node.
 
 **Parameters:**
 
-Name | Type |
------- | ------ |
-`k` | Buffer |
-`value` | Buffer |
-`keyRemainder` | Nibbles |
-`stack` | TrieNode[] |
+Name | Type | Description |
+------ | ------ | ------ |
+`k` | Buffer | - |
+`value` | Buffer | - |
+`keyRemainder` | Nibbles | - |
+`stack` | TrieNode[] |   |
 
 **Returns:** *Promise‹void›*
 
@@ -290,11 +295,9 @@ ___
 
 ▸ **_walkTrie**(`root`: Buffer, `onNode`: FoundNode): *Promise‹void›*
 
-*Defined in [baseTrie.ts:407](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L407)*
+*Defined in [baseTrie.ts:426](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L426)*
 
 Walks a trie until finished.
-
-**`method`** _walkTrie
 
 **Parameters:**
 
@@ -305,7 +308,7 @@ Name | Type | Description |
 
 **Returns:** *Promise‹void›*
 
-- returns when finished walking trie
+Returns when finished walking trie.
 
 ___
 
@@ -313,13 +316,9 @@ ___
 
 ▸ **batch**(`ops`: BatchDBOp[]): *Promise‹void›*
 
-*Defined in [baseTrie.ts:729](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L729)*
+*Defined in [baseTrie.ts:748](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L748)*
 
 The given hash of operations (key additions or deletions) are executed on the DB
-
-**`method`** batch
-
-**`memberof`** Trie
 
 **`example`** 
 const ops = [
@@ -333,9 +332,9 @@ await trie.batch(ops)
 
 **Parameters:**
 
-Name | Type |
------- | ------ |
-`ops` | BatchDBOp[] |
+Name | Type | Description |
+------ | ------ | ------ |
+`ops` | BatchDBOp[] |   |
 
 **Returns:** *Promise‹void›*
 
@@ -345,7 +344,7 @@ ___
 
 ▸ **checkRoot**(`root`: Buffer): *Promise‹boolean›*
 
-*Defined in [baseTrie.ts:745](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L745)*
+*Defined in [baseTrie.ts:764](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L764)*
 
 Checks if a given root exists.
 
@@ -363,7 +362,9 @@ ___
 
 ▸ **copy**(): *[Trie](_basetrie_.trie.md)*
 
-*Defined in [baseTrie.ts:708](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L708)*
+*Defined in [baseTrie.ts:730](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L730)*
+
+Creates a new trie backed by the same db.
 
 **Returns:** *[Trie](_basetrie_.trie.md)*
 
@@ -373,17 +374,13 @@ ___
 
 ▸ **createReadStream**(): *ReadStream*
 
-*Defined in [baseTrie.ts:702](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L702)*
+*Defined in [baseTrie.ts:723](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L723)*
 
 The `data` event is given an `Object` that has two properties; the `key` and the `value`. Both should be Buffers.
 
-**`method`** createReadStream
-
-**`memberof`** Trie
-
 **Returns:** *ReadStream*
 
-Returns a [stream](https://nodejs.org/dist/latest-v5.x/docs/api/stream.html#stream_class_stream_readable) of the contents of the `trie`
+Returns a [stream](https://nodejs.org/dist/latest-v12.x/docs/api/stream.html#stream_class_stream_readable) of the contents of the `trie`
 
 ___
 
@@ -391,19 +388,15 @@ ___
 
 ▸ **del**(`key`: Buffer): *Promise‹void›*
 
-*Defined in [baseTrie.ts:163](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L163)*
+*Defined in [baseTrie.ts:181](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L181)*
 
-deletes a value given a `key`
-
-**`method`** del
-
-**`memberof`** Trie
+Deletes a value given a `key`.
 
 **Parameters:**
 
-Name | Type |
------- | ------ |
-`key` | Buffer |
+Name | Type | Description |
+------ | ------ | ------ |
+`key` | Buffer |   |
 
 **Returns:** *Promise‹void›*
 
@@ -413,20 +406,16 @@ ___
 
 ▸ **findPath**(`key`: Buffer): *Promise‹Path›*
 
-*Defined in [baseTrie.ts:205](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L205)*
+*Defined in [baseTrie.ts:226](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L226)*
 
 Tries to find a path to the node for the given key.
 It returns a `stack` of nodes to the closet node.
-
-**`method`** findPath
-
-**`memberof`** Trie
 
 **Parameters:**
 
 Name | Type | Description |
 ------ | ------ | ------ |
-`key` | Buffer | the search key |
+`key` | Buffer | the search key  |
 
 **Returns:** *Promise‹Path›*
 
@@ -436,13 +425,9 @@ ___
 
 ▸ **get**(`key`: Buffer): *Promise‹Buffer | null›*
 
-*Defined in [baseTrie.ts:120](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L120)*
+*Defined in [baseTrie.ts:144](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L144)*
 
 Gets a value given a `key`
-
-**`method`** get
-
-**`memberof`** Trie
 
 **Parameters:**
 
@@ -452,7 +437,7 @@ Name | Type | Description |
 
 **Returns:** *Promise‹Buffer | null›*
 
-- Returns a promise that resolves to `Buffer` if a value was found or `null` if no value was found.
+A Promise that resolves to `Buffer` if a value was found or `null` if no value was found.
 
 ___
 
@@ -460,20 +445,16 @@ ___
 
 ▸ **put**(`key`: Buffer, `value`: Buffer): *Promise‹void›*
 
-*Defined in [baseTrie.ts:137](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L137)*
+*Defined in [baseTrie.ts:158](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L158)*
 
-Stores a given `value` at the given `key`
-
-**`method`** put
-
-**`memberof`** Trie
+Stores a given `value` at the given `key`.
 
 **Parameters:**
 
-Name | Type |
------- | ------ |
-`key` | Buffer |
-`value` | Buffer |
+Name | Type | Description |
+------ | ------ | ------ |
+`key` | Buffer | - |
+`value` | Buffer |   |
 
 **Returns:** *Promise‹void›*
 
@@ -483,7 +464,7 @@ ___
 
 ▸ **setRoot**(`value?`: Buffer): *void*
 
-*Defined in [baseTrie.ts:105](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L105)*
+*Defined in [baseTrie.ts:131](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L131)*
 
 **Parameters:**
 
@@ -495,18 +476,39 @@ Name | Type |
 
 ___
 
-### `Static` fromProof
+### `Static` createProof
 
-▸ **fromProof**(`proofNodes`: Buffer[], `proofTrie?`: [Trie](_basetrie_.trie.md)): *Promise‹[Trie](_basetrie_.trie.md)›*
+▸ **createProof**(`trie`: [Trie](_basetrie_.trie.md), `key`: Buffer): *Promise‹[Proof](../modules/_basetrie_.md#proof)›*
 
-*Defined in [baseTrie.ts:55](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L55)*
+*Defined in [baseTrie.ts:97](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L97)*
+
+Creates a proof from a trie and key that can be verified using [Trie.verifyProof](_basetrie_.trie.md#static-verifyproof).
 
 **Parameters:**
 
-Name | Type |
------- | ------ |
-`proofNodes` | Buffer[] |
-`proofTrie?` | [Trie](_basetrie_.trie.md) |
+Name | Type | Description |
+------ | ------ | ------ |
+`trie` | [Trie](_basetrie_.trie.md) | - |
+`key` | Buffer |   |
+
+**Returns:** *Promise‹[Proof](../modules/_basetrie_.md#proof)›*
+
+___
+
+### `Static` fromProof
+
+▸ **fromProof**(`proof`: [Proof](../modules/_basetrie_.md#proof), `trie?`: [Trie](_basetrie_.trie.md)): *Promise‹[Trie](_basetrie_.trie.md)›*
+
+*Defined in [baseTrie.ts:62](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L62)*
+
+Saves the nodes from a proof into the trie. If no trie is provided a new one wil be instantiated.
+
+**Parameters:**
+
+Name | Type | Description |
+------ | ------ | ------ |
+`proof` | [Proof](../modules/_basetrie_.md#proof) | - |
+`trie?` | [Trie](_basetrie_.trie.md) |   |
 
 **Returns:** *Promise‹[Trie](_basetrie_.trie.md)›*
 
@@ -514,26 +516,34 @@ ___
 
 ### `Static` prove
 
-▸ **prove**(`trie`: [Trie](_basetrie_.trie.md), `key`: Buffer): *Promise‹Buffer[]›*
+▸ **prove**(`trie`: [Trie](_basetrie_.trie.md), `key`: Buffer): *Promise‹[Proof](../modules/_basetrie_.md#proof)›*
 
-*Defined in [baseTrie.ts:75](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L75)*
+*Defined in [baseTrie.ts:88](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L88)*
+
+prove has been renamed to [Trie.createProof](_basetrie_.trie.md#static-createproof).
+
+**`deprecated`** 
 
 **Parameters:**
 
-Name | Type |
------- | ------ |
-`trie` | [Trie](_basetrie_.trie.md) |
-`key` | Buffer |
+Name | Type | Description |
+------ | ------ | ------ |
+`trie` | [Trie](_basetrie_.trie.md) | - |
+`key` | Buffer |   |
 
-**Returns:** *Promise‹Buffer[]›*
+**Returns:** *Promise‹[Proof](../modules/_basetrie_.md#proof)›*
 
 ___
 
 ### `Static` verifyProof
 
-▸ **verifyProof**(`rootHash`: Buffer, `key`: Buffer, `proofNodes`: Buffer[]): *Promise‹Buffer | null›*
+▸ **verifyProof**(`rootHash`: Buffer, `key`: Buffer, `proof`: [Proof](../modules/_basetrie_.md#proof)): *Promise‹Buffer | null›*
 
-*Defined in [baseTrie.ts:83](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L83)*
+*Defined in [baseTrie.ts:113](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L113)*
+
+Verifies a proof.
+
+**`throws`** If proof is found to be invalid.
 
 **Parameters:**
 
@@ -541,6 +551,8 @@ Name | Type |
 ------ | ------ |
 `rootHash` | Buffer |
 `key` | Buffer |
-`proofNodes` | Buffer[] |
+`proof` | [Proof](../modules/_basetrie_.md#proof) |
 
 **Returns:** *Promise‹Buffer | null›*
+
+The value from the key.

--- a/docs/classes/_checkpointtrie_.checkpointtrie.md
+++ b/docs/classes/_checkpointtrie_.checkpointtrie.md
@@ -31,16 +31,16 @@
 
 ### Methods
 
-* [_createInitialNode](_checkpointtrie_.checkpointtrie.md#_createinitialnode)
+* [_createInitialNode](_checkpointtrie_.checkpointtrie.md#private-_createinitialnode)
 * [_createScratchReadStream](_checkpointtrie_.checkpointtrie.md#private-_createscratchreadstream)
-* [_deleteNode](_checkpointtrie_.checkpointtrie.md#_deletenode)
+* [_deleteNode](_checkpointtrie_.checkpointtrie.md#private-_deletenode)
 * [_enterCpMode](_checkpointtrie_.checkpointtrie.md#private-_entercpmode)
 * [_exitCpMode](_checkpointtrie_.checkpointtrie.md#private-_exitcpmode)
 * [_findDbNodes](_checkpointtrie_.checkpointtrie.md#_finddbnodes)
-* [_findValueNodes](_checkpointtrie_.checkpointtrie.md#_findvaluenodes)
+* [_findValueNodes](_checkpointtrie_.checkpointtrie.md#private-_findvaluenodes)
 * [_formatNode](_checkpointtrie_.checkpointtrie.md#private-_formatnode)
-* [_lookupNode](_checkpointtrie_.checkpointtrie.md#_lookupnode)
-* [_putNode](_checkpointtrie_.checkpointtrie.md#_putnode)
+* [_lookupNode](_checkpointtrie_.checkpointtrie.md#private-_lookupnode)
+* [_putNode](_checkpointtrie_.checkpointtrie.md#private-_putnode)
 * [_saveStack](_checkpointtrie_.checkpointtrie.md#private-_savestack)
 * [_updateNode](_checkpointtrie_.checkpointtrie.md#private-_updatenode)
 * [_walkTrie](_checkpointtrie_.checkpointtrie.md#private-_walktrie)
@@ -56,6 +56,7 @@
 * [put](_checkpointtrie_.checkpointtrie.md#put)
 * [revert](_checkpointtrie_.checkpointtrie.md#revert)
 * [setRoot](_checkpointtrie_.checkpointtrie.md#setroot)
+* [createProof](_checkpointtrie_.checkpointtrie.md#static-createproof)
 * [fromProof](_checkpointtrie_.checkpointtrie.md#static-fromproof)
 * [prove](_checkpointtrie_.checkpointtrie.md#static-prove)
 * [verifyProof](_checkpointtrie_.checkpointtrie.md#static-verifyproof)
@@ -86,7 +87,7 @@ Name | Type |
 
 *Inherited from [Trie](_basetrie_.trie.md).[EMPTY_TRIE_ROOT](_basetrie_.trie.md#empty_trie_root)*
 
-*Defined in [baseTrie.ts:40](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L40)*
+*Defined in [baseTrie.ts:42](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L42)*
 
 ___
 
@@ -120,7 +121,7 @@ ___
 
 *Inherited from [Trie](_basetrie_.trie.md).[db](_basetrie_.trie.md#db)*
 
-*Defined in [baseTrie.ts:41](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L41)*
+*Defined in [baseTrie.ts:43](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L43)*
 
 ## Accessors
 
@@ -142,7 +143,7 @@ ___
 
 *Inherited from [Trie](_basetrie_.trie.md).[root](_basetrie_.trie.md#root)*
 
-*Defined in [baseTrie.ts:101](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L101)*
+*Defined in [baseTrie.ts:127](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L127)*
 
 **Returns:** *Buffer*
 
@@ -150,7 +151,7 @@ ___
 
 *Inherited from [Trie](_basetrie_.trie.md).[root](_basetrie_.trie.md#root)*
 
-*Defined in [baseTrie.ts:97](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L97)*
+*Defined in [baseTrie.ts:123](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L123)*
 
 **Parameters:**
 
@@ -162,13 +163,15 @@ Name | Type |
 
 ## Methods
 
-###  _createInitialNode
+### `Private` _createInitialNode
 
 ▸ **_createInitialNode**(`key`: Buffer, `value`: Buffer): *Promise‹void›*
 
-*Inherited from [Trie](_basetrie_.trie.md).[_createInitialNode](_basetrie_.trie.md#_createinitialnode)*
+*Inherited from [Trie](_basetrie_.trie.md).[_createInitialNode](_basetrie_.trie.md#private-_createinitialnode)*
 
-*Defined in [baseTrie.ts:659](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L659)*
+*Defined in [baseTrie.ts:683](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L683)*
+
+Creates the initial node from an empty tree.
 
 **Parameters:**
 
@@ -185,12 +188,10 @@ ___
 
 ▸ **_createScratchReadStream**(`scratchDb?`: ScratchDB): *ScratchReadStream‹›*
 
-*Defined in [checkpointTrie.ts:137](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/checkpointTrie.ts#L137)*
+*Defined in [checkpointTrie.ts:130](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/checkpointTrie.ts#L130)*
 
 Returns a `ScratchReadStream` based on the state updates
 since checkpoint.
-
-**`method`** createScratchReadStream
 
 **Parameters:**
 
@@ -202,13 +203,15 @@ Name | Type |
 
 ___
 
-###  _deleteNode
+### `Private` _deleteNode
 
 ▸ **_deleteNode**(`k`: Buffer, `stack`: TrieNode[]): *Promise‹void›*
 
-*Inherited from [Trie](_basetrie_.trie.md).[_deleteNode](_basetrie_.trie.md#_deletenode)*
+*Inherited from [Trie](_basetrie_.trie.md).[_deleteNode](_basetrie_.trie.md#private-_deletenode)*
 
-*Defined in [baseTrie.ts:537](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L537)*
+*Defined in [baseTrie.ts:558](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L558)*
+
+Deletes a node.
 
 **Parameters:**
 
@@ -225,7 +228,7 @@ ___
 
 ▸ **_enterCpMode**(): *void*
 
-*Defined in [checkpointTrie.ts:106](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/checkpointTrie.ts#L106)*
+*Defined in [checkpointTrie.ts:100](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/checkpointTrie.ts#L100)*
 
 Enter into checkpoint mode.
 
@@ -237,7 +240,7 @@ ___
 
 ▸ **_exitCpMode**(`commitState`: boolean): *Promise‹void›*
 
-*Defined in [checkpointTrie.ts:115](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/checkpointTrie.ts#L115)*
+*Defined in [checkpointTrie.ts:109](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/checkpointTrie.ts#L109)*
 
 Exit from checkpoint mode.
 
@@ -257,7 +260,7 @@ ___
 
 *Inherited from [Trie](_basetrie_.trie.md).[_findDbNodes](_basetrie_.trie.md#_finddbnodes)*
 
-*Defined in [baseTrie.ts:280](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L280)*
+*Defined in [baseTrie.ts:302](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L302)*
 
 **Parameters:**
 
@@ -269,13 +272,15 @@ Name | Type |
 
 ___
 
-###  _findValueNodes
+### `Private` _findValueNodes
 
 ▸ **_findValueNodes**(`onFound`: FoundNode): *Promise‹void›*
 
-*Inherited from [Trie](_basetrie_.trie.md).[_findValueNodes](_basetrie_.trie.md#_findvaluenodes)*
+*Inherited from [Trie](_basetrie_.trie.md).[_findValueNodes](_basetrie_.trie.md#private-_findvaluenodes)*
 
-*Defined in [baseTrie.ts:258](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L258)*
+*Defined in [baseTrie.ts:280](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L280)*
+
+Finds all nodes that store k,v values.
 
 **Parameters:**
 
@@ -293,34 +298,34 @@ ___
 
 *Overrides [Trie](_basetrie_.trie.md).[_formatNode](_basetrie_.trie.md#private-_formatnode)*
 
-*Defined in [checkpointTrie.ts:157](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/checkpointTrie.ts#L157)*
+*Defined in [checkpointTrie.ts:149](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/checkpointTrie.ts#L149)*
 
-Formats node to be saved by levelup.batch.
-
-**`method`** _formatNode
+Formats node to be saved by `levelup.batch`.
 
 **Parameters:**
 
 Name | Type | Default | Description |
 ------ | ------ | ------ | ------ |
-`node` | TrieNode | - | the node to format |
-`topLevel` | boolean | - | if the node is at the top level |
-`opStack` | BatchDBOp[] | - | the opStack to push the node's data |
-`remove` | boolean | false | whether to remove the node (only used for CheckpointTrie) |
+`node` | TrieNode | - | the node to format. |
+`topLevel` | boolean | - | if the node is at the top level. |
+`opStack` | BatchDBOp[] | - | the opStack to push the node's data. |
+`remove` | boolean | false | whether to remove the node (only used for CheckpointTrie). |
 
 **Returns:** *Buffer‹› | null | Buffer‹› | Buffer‹›[][]*
 
-- the node's hash used as the key or the rawNode
+The node's hash used as the key or the rawNode.
 
 ___
 
-###  _lookupNode
+### `Private` _lookupNode
 
 ▸ **_lookupNode**(`node`: Buffer | Buffer[]): *Promise‹TrieNode | null›*
 
-*Inherited from [Trie](_basetrie_.trie.md).[_lookupNode](_basetrie_.trie.md#_lookupnode)*
+*Inherited from [Trie](_basetrie_.trie.md).[_lookupNode](_basetrie_.trie.md#private-_lookupnode)*
 
-*Defined in [baseTrie.ts:173](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L173)*
+*Defined in [baseTrie.ts:194](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L194)*
+
+Retrieves a node from db by hash.
 
 **Parameters:**
 
@@ -332,13 +337,15 @@ Name | Type |
 
 ___
 
-###  _putNode
+### `Private` _putNode
 
 ▸ **_putNode**(`node`: TrieNode): *Promise‹void›*
 
-*Inherited from [Trie](_basetrie_.trie.md).[_putNode](_basetrie_.trie.md#_putnode)*
+*Inherited from [Trie](_basetrie_.trie.md).[_putNode](_basetrie_.trie.md#private-_putnode)*
 
-*Defined in [baseTrie.ts:191](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L191)*
+*Defined in [baseTrie.ts:215](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L215)*
+
+Writes a single node to db.
 
 **Parameters:**
 
@@ -356,11 +363,9 @@ ___
 
 *Inherited from [Trie](_basetrie_.trie.md).[_saveStack](_basetrie_.trie.md#private-_savestack)*
 
-*Defined in [baseTrie.ts:508](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L508)*
+*Defined in [baseTrie.ts:525](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L525)*
 
-saves a stack
-
-**`method`** _saveStack
+Saves a stack.
 
 **Parameters:**
 
@@ -368,7 +373,7 @@ Name | Type | Description |
 ------ | ------ | ------ |
 `key` | Nibbles | the key. Should follow the stack |
 `stack` | TrieNode[] | a stack of nodes to the value given by the key |
-`opStack` | BatchDBOp[] | a stack of levelup operations to commit at the end of this funciton |
+`opStack` | BatchDBOp[] | a stack of levelup operations to commit at the end of this funciton  |
 
 **Returns:** *Promise‹void›*
 
@@ -380,20 +385,18 @@ ___
 
 *Inherited from [Trie](_basetrie_.trie.md).[_updateNode](_basetrie_.trie.md#private-_updatenode)*
 
-*Defined in [baseTrie.ts:300](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L300)*
+*Defined in [baseTrie.ts:320](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L320)*
 
-Updates a node
-
-**`method`** _updateNode
+Updates a node.
 
 **Parameters:**
 
-Name | Type |
------- | ------ |
-`k` | Buffer |
-`value` | Buffer |
-`keyRemainder` | Nibbles |
-`stack` | TrieNode[] |
+Name | Type | Description |
+------ | ------ | ------ |
+`k` | Buffer | - |
+`value` | Buffer | - |
+`keyRemainder` | Nibbles | - |
+`stack` | TrieNode[] |   |
 
 **Returns:** *Promise‹void›*
 
@@ -405,11 +408,9 @@ ___
 
 *Inherited from [Trie](_basetrie_.trie.md).[_walkTrie](_basetrie_.trie.md#private-_walktrie)*
 
-*Defined in [baseTrie.ts:407](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L407)*
+*Defined in [baseTrie.ts:426](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L426)*
 
 Walks a trie until finished.
-
-**`method`** _walkTrie
 
 **Parameters:**
 
@@ -420,7 +421,7 @@ Name | Type | Description |
 
 **Returns:** *Promise‹void›*
 
-- returns when finished walking trie
+Returns when finished walking trie.
 
 ___
 
@@ -430,13 +431,9 @@ ___
 
 *Inherited from [Trie](_basetrie_.trie.md).[batch](_basetrie_.trie.md#batch)*
 
-*Defined in [baseTrie.ts:729](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L729)*
+*Defined in [baseTrie.ts:748](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L748)*
 
 The given hash of operations (key additions or deletions) are executed on the DB
-
-**`method`** batch
-
-**`memberof`** Trie
 
 **`example`** 
 const ops = [
@@ -450,9 +447,9 @@ await trie.batch(ops)
 
 **Parameters:**
 
-Name | Type |
------- | ------ |
-`ops` | BatchDBOp[] |
+Name | Type | Description |
+------ | ------ | ------ |
+`ops` | BatchDBOp[] |   |
 
 **Returns:** *Promise‹void›*
 
@@ -464,7 +461,7 @@ ___
 
 *Inherited from [Trie](_basetrie_.trie.md).[checkRoot](_basetrie_.trie.md#checkroot)*
 
-*Defined in [baseTrie.ts:745](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L745)*
+*Defined in [baseTrie.ts:764](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L764)*
 
 Checks if a given root exists.
 
@@ -482,12 +479,11 @@ ___
 
 ▸ **checkpoint**(): *void*
 
-*Defined in [checkpointTrie.ts:36](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/checkpointTrie.ts#L36)*
+*Defined in [checkpointTrie.ts:35](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/checkpointTrie.ts#L35)*
 
 Creates a checkpoint that can later be reverted to or committed.
-After this is called, no changes to the trie will be permanently saved
-until `commit` is called. Calling `db.put` overrides the checkpointing
-mechanism and would directly write to db.
+After this is called, no changes to the trie will be permanently saved until `commit` is called.
+To override the checkpointing mechanism use `_maindb.put` to write directly write to db.
 
 **Returns:** *void*
 
@@ -497,12 +493,10 @@ ___
 
 ▸ **commit**(): *Promise‹void›*
 
-*Defined in [checkpointTrie.ts:53](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/checkpointTrie.ts#L53)*
+*Defined in [checkpointTrie.ts:50](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/checkpointTrie.ts#L50)*
 
-Commits a checkpoint to disk, if current checkpoint is not nested. If
-nested, only sets the parent checkpoint as current checkpoint.
-
-**`method`** commit
+Commits a checkpoint to disk, if current checkpoint is not nested.
+If nested, only sets the parent checkpoint as current checkpoint.
 
 **`throws`** If not during a checkpoint phase
 
@@ -516,11 +510,9 @@ ___
 
 *Overrides [Trie](_basetrie_.trie.md).[copy](_basetrie_.trie.md#copy)*
 
-*Defined in [checkpointTrie.ts:91](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/checkpointTrie.ts#L91)*
+*Defined in [checkpointTrie.ts:85](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/checkpointTrie.ts#L85)*
 
-Returns a copy of the underlying trie with the interface
-of CheckpointTrie. If during a checkpoint, the copy will
-contain the checkpointing metadata (incl. reference to the same scratch).
+Returns a copy of the underlying trie with the interface of CheckpointTrie.
 
 **Parameters:**
 
@@ -538,17 +530,13 @@ ___
 
 *Inherited from [Trie](_basetrie_.trie.md).[createReadStream](_basetrie_.trie.md#createreadstream)*
 
-*Defined in [baseTrie.ts:702](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L702)*
+*Defined in [baseTrie.ts:723](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L723)*
 
 The `data` event is given an `Object` that has two properties; the `key` and the `value`. Both should be Buffers.
 
-**`method`** createReadStream
-
-**`memberof`** Trie
-
 **Returns:** *ReadStream*
 
-Returns a [stream](https://nodejs.org/dist/latest-v5.x/docs/api/stream.html#stream_class_stream_readable) of the contents of the `trie`
+Returns a [stream](https://nodejs.org/dist/latest-v12.x/docs/api/stream.html#stream_class_stream_readable) of the contents of the `trie`
 
 ___
 
@@ -558,19 +546,15 @@ ___
 
 *Inherited from [Trie](_basetrie_.trie.md).[del](_basetrie_.trie.md#del)*
 
-*Defined in [baseTrie.ts:163](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L163)*
+*Defined in [baseTrie.ts:181](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L181)*
 
-deletes a value given a `key`
-
-**`method`** del
-
-**`memberof`** Trie
+Deletes a value given a `key`.
 
 **Parameters:**
 
-Name | Type |
------- | ------ |
-`key` | Buffer |
+Name | Type | Description |
+------ | ------ | ------ |
+`key` | Buffer |   |
 
 **Returns:** *Promise‹void›*
 
@@ -582,20 +566,16 @@ ___
 
 *Inherited from [Trie](_basetrie_.trie.md).[findPath](_basetrie_.trie.md#findpath)*
 
-*Defined in [baseTrie.ts:205](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L205)*
+*Defined in [baseTrie.ts:226](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L226)*
 
 Tries to find a path to the node for the given key.
 It returns a `stack` of nodes to the closet node.
-
-**`method`** findPath
-
-**`memberof`** Trie
 
 **Parameters:**
 
 Name | Type | Description |
 ------ | ------ | ------ |
-`key` | Buffer | the search key |
+`key` | Buffer | the search key  |
 
 **Returns:** *Promise‹Path›*
 
@@ -607,13 +587,9 @@ ___
 
 *Inherited from [Trie](_basetrie_.trie.md).[get](_basetrie_.trie.md#get)*
 
-*Defined in [baseTrie.ts:120](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L120)*
+*Defined in [baseTrie.ts:144](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L144)*
 
 Gets a value given a `key`
-
-**`method`** get
-
-**`memberof`** Trie
 
 **Parameters:**
 
@@ -623,7 +599,7 @@ Name | Type | Description |
 
 **Returns:** *Promise‹Buffer | null›*
 
-- Returns a promise that resolves to `Buffer` if a value was found or `null` if no value was found.
+A Promise that resolves to `Buffer` if a value was found or `null` if no value was found.
 
 ___
 
@@ -633,20 +609,16 @@ ___
 
 *Inherited from [Trie](_basetrie_.trie.md).[put](_basetrie_.trie.md#put)*
 
-*Defined in [baseTrie.ts:137](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L137)*
+*Defined in [baseTrie.ts:158](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L158)*
 
-Stores a given `value` at the given `key`
-
-**`method`** put
-
-**`memberof`** Trie
+Stores a given `value` at the given `key`.
 
 **Parameters:**
 
-Name | Type |
------- | ------ |
-`key` | Buffer |
-`value` | Buffer |
+Name | Type | Description |
+------ | ------ | ------ |
+`key` | Buffer | - |
+`value` | Buffer |   |
 
 **Returns:** *Promise‹void›*
 
@@ -656,7 +628,7 @@ ___
 
 ▸ **revert**(): *Promise‹void›*
 
-*Defined in [checkpointTrie.ts:73](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/checkpointTrie.ts#L73)*
+*Defined in [checkpointTrie.ts:70](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/checkpointTrie.ts#L70)*
 
 Reverts the trie to the state it was at when `checkpoint` was first called.
 If during a nested checkpoint, sets root to most recent checkpoint, and sets
@@ -672,7 +644,7 @@ ___
 
 *Inherited from [Trie](_basetrie_.trie.md).[setRoot](_basetrie_.trie.md#setroot)*
 
-*Defined in [baseTrie.ts:105](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L105)*
+*Defined in [baseTrie.ts:131](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L131)*
 
 **Parameters:**
 
@@ -684,20 +656,43 @@ Name | Type |
 
 ___
 
-### `Static` fromProof
+### `Static` createProof
 
-▸ **fromProof**(`proofNodes`: Buffer[], `proofTrie?`: [Trie](_basetrie_.trie.md)): *Promise‹[Trie](_basetrie_.trie.md)›*
+▸ **createProof**(`trie`: [Trie](_basetrie_.trie.md), `key`: Buffer): *Promise‹[Proof](../modules/_basetrie_.md#proof)›*
 
-*Inherited from [Trie](_basetrie_.trie.md).[fromProof](_basetrie_.trie.md#static-fromproof)*
+*Inherited from [Trie](_basetrie_.trie.md).[createProof](_basetrie_.trie.md#static-createproof)*
 
-*Defined in [baseTrie.ts:55](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L55)*
+*Defined in [baseTrie.ts:97](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L97)*
+
+Creates a proof from a trie and key that can be verified using [Trie.verifyProof](_basetrie_.trie.md#static-verifyproof).
 
 **Parameters:**
 
-Name | Type |
------- | ------ |
-`proofNodes` | Buffer[] |
-`proofTrie?` | [Trie](_basetrie_.trie.md) |
+Name | Type | Description |
+------ | ------ | ------ |
+`trie` | [Trie](_basetrie_.trie.md) | - |
+`key` | Buffer |   |
+
+**Returns:** *Promise‹[Proof](../modules/_basetrie_.md#proof)›*
+
+___
+
+### `Static` fromProof
+
+▸ **fromProof**(`proof`: [Proof](../modules/_basetrie_.md#proof), `trie?`: [Trie](_basetrie_.trie.md)): *Promise‹[Trie](_basetrie_.trie.md)›*
+
+*Inherited from [Trie](_basetrie_.trie.md).[fromProof](_basetrie_.trie.md#static-fromproof)*
+
+*Defined in [baseTrie.ts:62](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L62)*
+
+Saves the nodes from a proof into the trie. If no trie is provided a new one wil be instantiated.
+
+**Parameters:**
+
+Name | Type | Description |
+------ | ------ | ------ |
+`proof` | [Proof](../modules/_basetrie_.md#proof) | - |
+`trie?` | [Trie](_basetrie_.trie.md) |   |
 
 **Returns:** *Promise‹[Trie](_basetrie_.trie.md)›*
 
@@ -705,30 +700,38 @@ ___
 
 ### `Static` prove
 
-▸ **prove**(`trie`: [Trie](_basetrie_.trie.md), `key`: Buffer): *Promise‹Buffer[]›*
+▸ **prove**(`trie`: [Trie](_basetrie_.trie.md), `key`: Buffer): *Promise‹[Proof](../modules/_basetrie_.md#proof)›*
 
 *Inherited from [Trie](_basetrie_.trie.md).[prove](_basetrie_.trie.md#static-prove)*
 
-*Defined in [baseTrie.ts:75](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L75)*
+*Defined in [baseTrie.ts:88](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L88)*
+
+prove has been renamed to [Trie.createProof](_basetrie_.trie.md#static-createproof).
+
+**`deprecated`** 
 
 **Parameters:**
 
-Name | Type |
------- | ------ |
-`trie` | [Trie](_basetrie_.trie.md) |
-`key` | Buffer |
+Name | Type | Description |
+------ | ------ | ------ |
+`trie` | [Trie](_basetrie_.trie.md) | - |
+`key` | Buffer |   |
 
-**Returns:** *Promise‹Buffer[]›*
+**Returns:** *Promise‹[Proof](../modules/_basetrie_.md#proof)›*
 
 ___
 
 ### `Static` verifyProof
 
-▸ **verifyProof**(`rootHash`: Buffer, `key`: Buffer, `proofNodes`: Buffer[]): *Promise‹Buffer | null›*
+▸ **verifyProof**(`rootHash`: Buffer, `key`: Buffer, `proof`: [Proof](../modules/_basetrie_.md#proof)): *Promise‹Buffer | null›*
 
 *Inherited from [Trie](_basetrie_.trie.md).[verifyProof](_basetrie_.trie.md#static-verifyproof)*
 
-*Defined in [baseTrie.ts:83](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L83)*
+*Defined in [baseTrie.ts:113](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L113)*
+
+Verifies a proof.
+
+**`throws`** If proof is found to be invalid.
 
 **Parameters:**
 
@@ -736,6 +739,8 @@ Name | Type |
 ------ | ------ |
 `rootHash` | Buffer |
 `key` | Buffer |
-`proofNodes` | Buffer[] |
+`proof` | [Proof](../modules/_basetrie_.md#proof) |
 
 **Returns:** *Promise‹Buffer | null›*
+
+The value from the key.

--- a/docs/classes/_secure_.securetrie.md
+++ b/docs/classes/_secure_.securetrie.md
@@ -3,7 +3,7 @@
 # Class: SecureTrie
 
 You can create a secure Trie where the keys are automatically hashed
-using **keccak256** by using `require('merkle-patricia-tree/secure')`.
+using **keccak256** by using `require('merkle-patricia-tree').SecureTrie`.
 It has the same methods and constructor as `Trie`.
 
 **`class`** SecureTrie
@@ -37,16 +37,16 @@ It has the same methods and constructor as `Trie`.
 
 ### Methods
 
-* [_createInitialNode](_secure_.securetrie.md#_createinitialnode)
+* [_createInitialNode](_secure_.securetrie.md#private-_createinitialnode)
 * [_createScratchReadStream](_secure_.securetrie.md#private-_createscratchreadstream)
-* [_deleteNode](_secure_.securetrie.md#_deletenode)
+* [_deleteNode](_secure_.securetrie.md#private-_deletenode)
 * [_enterCpMode](_secure_.securetrie.md#private-_entercpmode)
 * [_exitCpMode](_secure_.securetrie.md#private-_exitcpmode)
 * [_findDbNodes](_secure_.securetrie.md#_finddbnodes)
-* [_findValueNodes](_secure_.securetrie.md#_findvaluenodes)
+* [_findValueNodes](_secure_.securetrie.md#private-_findvaluenodes)
 * [_formatNode](_secure_.securetrie.md#private-_formatnode)
-* [_lookupNode](_secure_.securetrie.md#_lookupnode)
-* [_putNode](_secure_.securetrie.md#_putnode)
+* [_lookupNode](_secure_.securetrie.md#private-_lookupnode)
+* [_putNode](_secure_.securetrie.md#private-_putnode)
 * [_saveStack](_secure_.securetrie.md#private-_savestack)
 * [_updateNode](_secure_.securetrie.md#private-_updatenode)
 * [_walkTrie](_secure_.securetrie.md#private-_walktrie)
@@ -62,6 +62,7 @@ It has the same methods and constructor as `Trie`.
 * [put](_secure_.securetrie.md#put)
 * [revert](_secure_.securetrie.md#revert)
 * [setRoot](_secure_.securetrie.md#setroot)
+* [createProof](_secure_.securetrie.md#static-createproof)
 * [fromProof](_secure_.securetrie.md#static-fromproof)
 * [prove](_secure_.securetrie.md#static-prove)
 * [verifyProof](_secure_.securetrie.md#static-verifyproof)
@@ -74,7 +75,7 @@ It has the same methods and constructor as `Trie`.
 
 *Overrides [CheckpointTrie](_checkpointtrie_.checkpointtrie.md).[constructor](_checkpointtrie_.checkpointtrie.md#constructor)*
 
-*Defined in [secure.ts:12](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/secure.ts#L12)*
+*Defined in [secure.ts:13](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/secure.ts#L13)*
 
 **Parameters:**
 
@@ -92,7 +93,7 @@ Name | Type |
 
 *Inherited from [Trie](_basetrie_.trie.md).[EMPTY_TRIE_ROOT](_basetrie_.trie.md#empty_trie_root)*
 
-*Defined in [baseTrie.ts:40](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L40)*
+*Defined in [baseTrie.ts:42](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L42)*
 
 ___
 
@@ -132,7 +133,7 @@ ___
 
 *Inherited from [Trie](_basetrie_.trie.md).[db](_basetrie_.trie.md#db)*
 
-*Defined in [baseTrie.ts:41](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L41)*
+*Defined in [baseTrie.ts:43](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L43)*
 
 ## Accessors
 
@@ -156,7 +157,7 @@ ___
 
 *Inherited from [Trie](_basetrie_.trie.md).[root](_basetrie_.trie.md#root)*
 
-*Defined in [baseTrie.ts:101](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L101)*
+*Defined in [baseTrie.ts:127](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L127)*
 
 **Returns:** *Buffer*
 
@@ -164,7 +165,7 @@ ___
 
 *Inherited from [Trie](_basetrie_.trie.md).[root](_basetrie_.trie.md#root)*
 
-*Defined in [baseTrie.ts:97](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L97)*
+*Defined in [baseTrie.ts:123](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L123)*
 
 **Parameters:**
 
@@ -176,13 +177,15 @@ Name | Type |
 
 ## Methods
 
-###  _createInitialNode
+### `Private` _createInitialNode
 
 ▸ **_createInitialNode**(`key`: Buffer, `value`: Buffer): *Promise‹void›*
 
-*Inherited from [Trie](_basetrie_.trie.md).[_createInitialNode](_basetrie_.trie.md#_createinitialnode)*
+*Inherited from [Trie](_basetrie_.trie.md).[_createInitialNode](_basetrie_.trie.md#private-_createinitialnode)*
 
-*Defined in [baseTrie.ts:659](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L659)*
+*Defined in [baseTrie.ts:683](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L683)*
+
+Creates the initial node from an empty tree.
 
 **Parameters:**
 
@@ -201,12 +204,10 @@ ___
 
 *Inherited from [CheckpointTrie](_checkpointtrie_.checkpointtrie.md).[_createScratchReadStream](_checkpointtrie_.checkpointtrie.md#private-_createscratchreadstream)*
 
-*Defined in [checkpointTrie.ts:137](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/checkpointTrie.ts#L137)*
+*Defined in [checkpointTrie.ts:130](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/checkpointTrie.ts#L130)*
 
 Returns a `ScratchReadStream` based on the state updates
 since checkpoint.
-
-**`method`** createScratchReadStream
 
 **Parameters:**
 
@@ -218,13 +219,15 @@ Name | Type |
 
 ___
 
-###  _deleteNode
+### `Private` _deleteNode
 
 ▸ **_deleteNode**(`k`: Buffer, `stack`: TrieNode[]): *Promise‹void›*
 
-*Inherited from [Trie](_basetrie_.trie.md).[_deleteNode](_basetrie_.trie.md#_deletenode)*
+*Inherited from [Trie](_basetrie_.trie.md).[_deleteNode](_basetrie_.trie.md#private-_deletenode)*
 
-*Defined in [baseTrie.ts:537](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L537)*
+*Defined in [baseTrie.ts:558](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L558)*
+
+Deletes a node.
 
 **Parameters:**
 
@@ -243,7 +246,7 @@ ___
 
 *Inherited from [CheckpointTrie](_checkpointtrie_.checkpointtrie.md).[_enterCpMode](_checkpointtrie_.checkpointtrie.md#private-_entercpmode)*
 
-*Defined in [checkpointTrie.ts:106](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/checkpointTrie.ts#L106)*
+*Defined in [checkpointTrie.ts:100](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/checkpointTrie.ts#L100)*
 
 Enter into checkpoint mode.
 
@@ -257,7 +260,7 @@ ___
 
 *Inherited from [CheckpointTrie](_checkpointtrie_.checkpointtrie.md).[_exitCpMode](_checkpointtrie_.checkpointtrie.md#private-_exitcpmode)*
 
-*Defined in [checkpointTrie.ts:115](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/checkpointTrie.ts#L115)*
+*Defined in [checkpointTrie.ts:109](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/checkpointTrie.ts#L109)*
 
 Exit from checkpoint mode.
 
@@ -277,7 +280,7 @@ ___
 
 *Inherited from [Trie](_basetrie_.trie.md).[_findDbNodes](_basetrie_.trie.md#_finddbnodes)*
 
-*Defined in [baseTrie.ts:280](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L280)*
+*Defined in [baseTrie.ts:302](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L302)*
 
 **Parameters:**
 
@@ -289,13 +292,15 @@ Name | Type |
 
 ___
 
-###  _findValueNodes
+### `Private` _findValueNodes
 
 ▸ **_findValueNodes**(`onFound`: FoundNode): *Promise‹void›*
 
-*Inherited from [Trie](_basetrie_.trie.md).[_findValueNodes](_basetrie_.trie.md#_findvaluenodes)*
+*Inherited from [Trie](_basetrie_.trie.md).[_findValueNodes](_basetrie_.trie.md#private-_findvaluenodes)*
 
-*Defined in [baseTrie.ts:258](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L258)*
+*Defined in [baseTrie.ts:280](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L280)*
+
+Finds all nodes that store k,v values.
 
 **Parameters:**
 
@@ -315,34 +320,34 @@ ___
 
 *Overrides [Trie](_basetrie_.trie.md).[_formatNode](_basetrie_.trie.md#private-_formatnode)*
 
-*Defined in [checkpointTrie.ts:157](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/checkpointTrie.ts#L157)*
+*Defined in [checkpointTrie.ts:149](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/checkpointTrie.ts#L149)*
 
-Formats node to be saved by levelup.batch.
-
-**`method`** _formatNode
+Formats node to be saved by `levelup.batch`.
 
 **Parameters:**
 
 Name | Type | Default | Description |
 ------ | ------ | ------ | ------ |
-`node` | TrieNode | - | the node to format |
-`topLevel` | boolean | - | if the node is at the top level |
-`opStack` | BatchDBOp[] | - | the opStack to push the node's data |
-`remove` | boolean | false | whether to remove the node (only used for CheckpointTrie) |
+`node` | TrieNode | - | the node to format. |
+`topLevel` | boolean | - | if the node is at the top level. |
+`opStack` | BatchDBOp[] | - | the opStack to push the node's data. |
+`remove` | boolean | false | whether to remove the node (only used for CheckpointTrie). |
 
 **Returns:** *Buffer‹› | null | Buffer‹› | Buffer‹›[][]*
 
-- the node's hash used as the key or the rawNode
+The node's hash used as the key or the rawNode.
 
 ___
 
-###  _lookupNode
+### `Private` _lookupNode
 
 ▸ **_lookupNode**(`node`: Buffer | Buffer[]): *Promise‹TrieNode | null›*
 
-*Inherited from [Trie](_basetrie_.trie.md).[_lookupNode](_basetrie_.trie.md#_lookupnode)*
+*Inherited from [Trie](_basetrie_.trie.md).[_lookupNode](_basetrie_.trie.md#private-_lookupnode)*
 
-*Defined in [baseTrie.ts:173](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L173)*
+*Defined in [baseTrie.ts:194](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L194)*
+
+Retrieves a node from db by hash.
 
 **Parameters:**
 
@@ -354,13 +359,15 @@ Name | Type |
 
 ___
 
-###  _putNode
+### `Private` _putNode
 
 ▸ **_putNode**(`node`: TrieNode): *Promise‹void›*
 
-*Inherited from [Trie](_basetrie_.trie.md).[_putNode](_basetrie_.trie.md#_putnode)*
+*Inherited from [Trie](_basetrie_.trie.md).[_putNode](_basetrie_.trie.md#private-_putnode)*
 
-*Defined in [baseTrie.ts:191](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L191)*
+*Defined in [baseTrie.ts:215](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L215)*
+
+Writes a single node to db.
 
 **Parameters:**
 
@@ -378,11 +385,9 @@ ___
 
 *Inherited from [Trie](_basetrie_.trie.md).[_saveStack](_basetrie_.trie.md#private-_savestack)*
 
-*Defined in [baseTrie.ts:508](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L508)*
+*Defined in [baseTrie.ts:525](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L525)*
 
-saves a stack
-
-**`method`** _saveStack
+Saves a stack.
 
 **Parameters:**
 
@@ -390,7 +395,7 @@ Name | Type | Description |
 ------ | ------ | ------ |
 `key` | Nibbles | the key. Should follow the stack |
 `stack` | TrieNode[] | a stack of nodes to the value given by the key |
-`opStack` | BatchDBOp[] | a stack of levelup operations to commit at the end of this funciton |
+`opStack` | BatchDBOp[] | a stack of levelup operations to commit at the end of this funciton  |
 
 **Returns:** *Promise‹void›*
 
@@ -402,20 +407,18 @@ ___
 
 *Inherited from [Trie](_basetrie_.trie.md).[_updateNode](_basetrie_.trie.md#private-_updatenode)*
 
-*Defined in [baseTrie.ts:300](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L300)*
+*Defined in [baseTrie.ts:320](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L320)*
 
-Updates a node
-
-**`method`** _updateNode
+Updates a node.
 
 **Parameters:**
 
-Name | Type |
------- | ------ |
-`k` | Buffer |
-`value` | Buffer |
-`keyRemainder` | Nibbles |
-`stack` | TrieNode[] |
+Name | Type | Description |
+------ | ------ | ------ |
+`k` | Buffer | - |
+`value` | Buffer | - |
+`keyRemainder` | Nibbles | - |
+`stack` | TrieNode[] |   |
 
 **Returns:** *Promise‹void›*
 
@@ -427,11 +430,9 @@ ___
 
 *Inherited from [Trie](_basetrie_.trie.md).[_walkTrie](_basetrie_.trie.md#private-_walktrie)*
 
-*Defined in [baseTrie.ts:407](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L407)*
+*Defined in [baseTrie.ts:426](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L426)*
 
 Walks a trie until finished.
-
-**`method`** _walkTrie
 
 **Parameters:**
 
@@ -442,7 +443,7 @@ Name | Type | Description |
 
 **Returns:** *Promise‹void›*
 
-- returns when finished walking trie
+Returns when finished walking trie.
 
 ___
 
@@ -452,13 +453,9 @@ ___
 
 *Inherited from [Trie](_basetrie_.trie.md).[batch](_basetrie_.trie.md#batch)*
 
-*Defined in [baseTrie.ts:729](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L729)*
+*Defined in [baseTrie.ts:748](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L748)*
 
 The given hash of operations (key additions or deletions) are executed on the DB
-
-**`method`** batch
-
-**`memberof`** Trie
 
 **`example`** 
 const ops = [
@@ -472,9 +469,9 @@ await trie.batch(ops)
 
 **Parameters:**
 
-Name | Type |
------- | ------ |
-`ops` | BatchDBOp[] |
+Name | Type | Description |
+------ | ------ | ------ |
+`ops` | BatchDBOp[] |   |
 
 **Returns:** *Promise‹void›*
 
@@ -486,7 +483,7 @@ ___
 
 *Inherited from [Trie](_basetrie_.trie.md).[checkRoot](_basetrie_.trie.md#checkroot)*
 
-*Defined in [baseTrie.ts:745](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L745)*
+*Defined in [baseTrie.ts:764](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L764)*
 
 Checks if a given root exists.
 
@@ -506,12 +503,11 @@ ___
 
 *Inherited from [CheckpointTrie](_checkpointtrie_.checkpointtrie.md).[checkpoint](_checkpointtrie_.checkpointtrie.md#checkpoint)*
 
-*Defined in [checkpointTrie.ts:36](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/checkpointTrie.ts#L36)*
+*Defined in [checkpointTrie.ts:35](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/checkpointTrie.ts#L35)*
 
 Creates a checkpoint that can later be reverted to or committed.
-After this is called, no changes to the trie will be permanently saved
-until `commit` is called. Calling `db.put` overrides the checkpointing
-mechanism and would directly write to db.
+After this is called, no changes to the trie will be permanently saved until `commit` is called.
+To override the checkpointing mechanism use `_maindb.put` to write directly write to db.
 
 **Returns:** *void*
 
@@ -523,12 +519,10 @@ ___
 
 *Inherited from [CheckpointTrie](_checkpointtrie_.checkpointtrie.md).[commit](_checkpointtrie_.checkpointtrie.md#commit)*
 
-*Defined in [checkpointTrie.ts:53](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/checkpointTrie.ts#L53)*
+*Defined in [checkpointTrie.ts:50](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/checkpointTrie.ts#L50)*
 
-Commits a checkpoint to disk, if current checkpoint is not nested. If
-nested, only sets the parent checkpoint as current checkpoint.
-
-**`method`** commit
+Commits a checkpoint to disk, if current checkpoint is not nested.
+If nested, only sets the parent checkpoint as current checkpoint.
 
 **`throws`** If not during a checkpoint phase
 
@@ -538,11 +532,19 @@ ___
 
 ###  copy
 
-▸ **copy**(): *[SecureTrie](_secure_.securetrie.md)*
+▸ **copy**(`includeCheckpoints`: boolean): *[SecureTrie](_secure_.securetrie.md)*
 
 *Overrides [CheckpointTrie](_checkpointtrie_.checkpointtrie.md).[copy](_checkpointtrie_.checkpointtrie.md#copy)*
 
-*Defined in [secure.ts:27](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/secure.ts#L27)*
+*Defined in [secure.ts:55](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/secure.ts#L55)*
+
+Returns a copy of the underlying trie with the interface of SecureTrie.
+
+**Parameters:**
+
+Name | Type | Default | Description |
+------ | ------ | ------ | ------ |
+`includeCheckpoints` | boolean | true | If true and during a checkpoint, the copy will contain the checkpointing metadata and will use the same scratch as underlying db.  |
 
 **Returns:** *[SecureTrie](_secure_.securetrie.md)*
 
@@ -554,17 +556,13 @@ ___
 
 *Inherited from [Trie](_basetrie_.trie.md).[createReadStream](_basetrie_.trie.md#createreadstream)*
 
-*Defined in [baseTrie.ts:702](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L702)*
+*Defined in [baseTrie.ts:723](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L723)*
 
 The `data` event is given an `Object` that has two properties; the `key` and the `value`. Both should be Buffers.
 
-**`method`** createReadStream
-
-**`memberof`** Trie
-
 **Returns:** *ReadStream*
 
-Returns a [stream](https://nodejs.org/dist/latest-v5.x/docs/api/stream.html#stream_class_stream_readable) of the contents of the `trie`
+Returns a [stream](https://nodejs.org/dist/latest-v12.x/docs/api/stream.html#stream_class_stream_readable) of the contents of the `trie`
 
 ___
 
@@ -574,13 +572,15 @@ ___
 
 *Overrides [Trie](_basetrie_.trie.md).[del](_basetrie_.trie.md#del)*
 
-*Defined in [secure.ts:52](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/secure.ts#L52)*
+*Defined in [secure.ts:91](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/secure.ts#L91)*
+
+Deletes a value given a `key`.
 
 **Parameters:**
 
-Name | Type |
------- | ------ |
-`key` | Buffer |
+Name | Type | Description |
+------ | ------ | ------ |
+`key` | Buffer |   |
 
 **Returns:** *Promise‹void›*
 
@@ -592,20 +592,16 @@ ___
 
 *Inherited from [Trie](_basetrie_.trie.md).[findPath](_basetrie_.trie.md#findpath)*
 
-*Defined in [baseTrie.ts:205](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L205)*
+*Defined in [baseTrie.ts:226](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L226)*
 
 Tries to find a path to the node for the given key.
 It returns a `stack` of nodes to the closet node.
-
-**`method`** findPath
-
-**`memberof`** Trie
 
 **Parameters:**
 
 Name | Type | Description |
 ------ | ------ | ------ |
-`key` | Buffer | the search key |
+`key` | Buffer | the search key  |
 
 **Returns:** *Promise‹Path›*
 
@@ -617,15 +613,19 @@ ___
 
 *Overrides [Trie](_basetrie_.trie.md).[get](_basetrie_.trie.md#get)*
 
-*Defined in [secure.ts:33](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/secure.ts#L33)*
+*Defined in [secure.ts:66](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/secure.ts#L66)*
+
+Gets a value given a `key`
 
 **Parameters:**
 
-Name | Type |
------- | ------ |
-`key` | Buffer |
+Name | Type | Description |
+------ | ------ | ------ |
+`key` | Buffer | the key to search for |
 
 **Returns:** *Promise‹Buffer | null›*
+
+A Promise that resolves to `Buffer` if a value was found or `null` if no value was found.
 
 ___
 
@@ -635,10 +635,10 @@ ___
 
 *Overrides [Trie](_basetrie_.trie.md).[put](_basetrie_.trie.md#put)*
 
-*Defined in [secure.ts:43](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/secure.ts#L43)*
+*Defined in [secure.ts:78](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/secure.ts#L78)*
 
-For a falsey value, use the original key
-to avoid double hashing the key.
+Stores a given `value` at the given `key`.
+For a falsey value, use the original key to avoid double hashing the key.
 
 **Parameters:**
 
@@ -657,7 +657,7 @@ ___
 
 *Inherited from [CheckpointTrie](_checkpointtrie_.checkpointtrie.md).[revert](_checkpointtrie_.checkpointtrie.md#revert)*
 
-*Defined in [checkpointTrie.ts:73](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/checkpointTrie.ts#L73)*
+*Defined in [checkpointTrie.ts:70](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/checkpointTrie.ts#L70)*
 
 Reverts the trie to the state it was at when `checkpoint` was first called.
 If during a nested checkpoint, sets root to most recent checkpoint, and sets
@@ -673,7 +673,7 @@ ___
 
 *Inherited from [Trie](_basetrie_.trie.md).[setRoot](_basetrie_.trie.md#setroot)*
 
-*Defined in [baseTrie.ts:105](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L105)*
+*Defined in [baseTrie.ts:131](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L131)*
 
 **Parameters:**
 
@@ -685,20 +685,43 @@ Name | Type |
 
 ___
 
-### `Static` fromProof
+### `Static` createProof
 
-▸ **fromProof**(`proofNodes`: Buffer[], `proofTrie?`: [Trie](_basetrie_.trie.md)): *Promise‹[Trie](_basetrie_.trie.md)›*
+▸ **createProof**(`trie`: [SecureTrie](_secure_.securetrie.md), `key`: Buffer): *Promise‹[Proof](../modules/_basetrie_.md#proof)›*
 
-*Inherited from [Trie](_basetrie_.trie.md).[fromProof](_basetrie_.trie.md#static-fromproof)*
+*Overrides [Trie](_basetrie_.trie.md).[createProof](_basetrie_.trie.md#static-createproof)*
 
-*Defined in [baseTrie.ts:55](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L55)*
+*Defined in [secure.ts:33](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/secure.ts#L33)*
+
+Creates a proof that can be verified using [SecureTrie.verifyProof](_secure_.securetrie.md#static-verifyproof).
 
 **Parameters:**
 
-Name | Type |
------- | ------ |
-`proofNodes` | Buffer[] |
-`proofTrie?` | [Trie](_basetrie_.trie.md) |
+Name | Type | Description |
+------ | ------ | ------ |
+`trie` | [SecureTrie](_secure_.securetrie.md) | - |
+`key` | Buffer |   |
+
+**Returns:** *Promise‹[Proof](../modules/_basetrie_.md#proof)›*
+
+___
+
+### `Static` fromProof
+
+▸ **fromProof**(`proof`: [Proof](../modules/_basetrie_.md#proof), `trie?`: [Trie](_basetrie_.trie.md)): *Promise‹[Trie](_basetrie_.trie.md)›*
+
+*Inherited from [Trie](_basetrie_.trie.md).[fromProof](_basetrie_.trie.md#static-fromproof)*
+
+*Defined in [baseTrie.ts:62](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L62)*
+
+Saves the nodes from a proof into the trie. If no trie is provided a new one wil be instantiated.
+
+**Parameters:**
+
+Name | Type | Description |
+------ | ------ | ------ |
+`proof` | [Proof](../modules/_basetrie_.md#proof) | - |
+`trie?` | [Trie](_basetrie_.trie.md) |   |
 
 **Returns:** *Promise‹[Trie](_basetrie_.trie.md)›*
 
@@ -706,30 +729,38 @@ ___
 
 ### `Static` prove
 
-▸ **prove**(`trie`: [SecureTrie](_secure_.securetrie.md), `key`: Buffer): *Promise‹Buffer[]›*
+▸ **prove**(`trie`: [SecureTrie](_secure_.securetrie.md), `key`: Buffer): *Promise‹[Proof](../modules/_basetrie_.md#proof)›*
 
 *Overrides [Trie](_basetrie_.trie.md).[prove](_basetrie_.trie.md#static-prove)*
 
-*Defined in [secure.ts:17](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/secure.ts#L17)*
+*Defined in [secure.ts:24](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/secure.ts#L24)*
+
+prove has been renamed to [SecureTrie.createProof](_secure_.securetrie.md#static-createproof).
+
+**`deprecated`** 
 
 **Parameters:**
 
-Name | Type |
------- | ------ |
-`trie` | [SecureTrie](_secure_.securetrie.md) |
-`key` | Buffer |
+Name | Type | Description |
+------ | ------ | ------ |
+`trie` | [SecureTrie](_secure_.securetrie.md) | - |
+`key` | Buffer |   |
 
-**Returns:** *Promise‹Buffer[]›*
+**Returns:** *Promise‹[Proof](../modules/_basetrie_.md#proof)›*
 
 ___
 
 ### `Static` verifyProof
 
-▸ **verifyProof**(`rootHash`: Buffer, `key`: Buffer, `proof`: Buffer[]): *Promise‹Buffer | null›*
+▸ **verifyProof**(`rootHash`: Buffer, `key`: Buffer, `proof`: [Proof](../modules/_basetrie_.md#proof)): *Promise‹Buffer | null›*
 
 *Overrides [Trie](_basetrie_.trie.md).[verifyProof](_basetrie_.trie.md#static-verifyproof)*
 
-*Defined in [secure.ts:22](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/secure.ts#L22)*
+*Defined in [secure.ts:46](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/secure.ts#L46)*
+
+Verifies a proof.
+
+**`throws`** If proof is found to be invalid.
 
 **Parameters:**
 
@@ -737,6 +768,8 @@ Name | Type |
 ------ | ------ |
 `rootHash` | Buffer |
 `key` | Buffer |
-`proof` | Buffer[] |
+`proof` | [Proof](../modules/_basetrie_.md#proof) |
 
 **Returns:** *Promise‹Buffer | null›*
+
+The value from the key.

--- a/docs/modules/_basetrie_.md
+++ b/docs/modules/_basetrie_.md
@@ -7,3 +7,15 @@
 ### Classes
 
 * [Trie](../classes/_basetrie_.trie.md)
+
+### Type aliases
+
+* [Proof](_basetrie_.md#proof)
+
+## Type aliases
+
+###  Proof
+
+Ƭ **Proof**: *Buffer[]*
+
+*Defined in [baseTrie.ts:29](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L29)*

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "ts-node": "^8.8.1",
     "tslint": "^5.18.0",
     "typedoc": "next",
-    "typedoc-plugin-markdown": "^2.2.16",
+    "typedoc-plugin-markdown": "^2.2.17",
     "typescript": "^3.7.5",
     "typestrict": "^1.0.2"
   },

--- a/src/baseTrie.ts
+++ b/src/baseTrie.ts
@@ -18,6 +18,8 @@ import {
 } from './trieNode'
 const assert = require('assert')
 
+export type Proof = Buffer[]
+
 interface Path {
   node: TrieNode | null
   remaining: Nibbles
@@ -25,8 +27,6 @@ interface Path {
 }
 
 type FoundNode = (nodeRef: Buffer, node: TrieNode, key: Nibbles, walkController: any) => void
-
-export type Proof = Buffer[]
 
 /**
  * Use `import { BaseTrie as Trie } from 'merkle-patricia-tree'` for the base interface.

--- a/src/baseTrie.ts
+++ b/src/baseTrie.ts
@@ -26,6 +26,8 @@ interface Path {
 
 type FoundNode = (nodeRef: Buffer, node: TrieNode, key: Nibbles, walkController: any) => void
 
+export type Proof = Buffer[]
+
 /**
  * Use `import { BaseTrie as Trie } from 'merkle-patricia-tree'` for the base interface.
  * In Ethereum applications stick with the Secure Trie Overlay `import { SecureTrie as Trie } from 'merkle-patricia-tree'`.
@@ -52,8 +54,13 @@ export class Trie {
     }
   }
 
-  static async fromProof(proofNodes: Buffer[], proofTrie?: Trie): Promise<Trie> {
-    let opStack = proofNodes.map((nodeValue) => {
+  /**
+   * Saves the nodes from a proof into the trie. If no trie is provided a new one wil be instantiated.
+   * @param {Proof} proof
+   * @param {Trie} trie
+   */
+  static async fromProof(proof: Proof, trie?: Trie): Promise<Trie> {
+    let opStack = proof.map((nodeValue) => {
       return {
         type: 'put',
         key: keccak(nodeValue),
@@ -61,18 +68,33 @@ export class Trie {
       } as PutBatch
     })
 
-    if (!proofTrie) {
-      proofTrie = new Trie()
+    if (!trie) {
+      trie = new Trie()
       if (opStack[0]) {
-        proofTrie.root = opStack[0].key
+        trie.root = opStack[0].key
       }
     }
 
-    await proofTrie.db.batch(opStack)
-    return proofTrie
+    await trie.db.batch(opStack)
+    return trie
   }
 
-  static async prove(trie: Trie, key: Buffer): Promise<Buffer[]> {
+  /**
+   * prove has been renamed to [[Trie.createProof]].
+   * @deprecated
+   * @param {Trie} trie
+   * @param {Buffer} key
+   */
+  static async prove(trie: Trie, key: Buffer): Promise<Proof> {
+    return this.createProof(trie, key)
+  }
+
+  /**
+   * Creates a proof from a trie and key that can be verified using [[Trie.verifyProof]].
+   * @param {Trie} trie
+   * @param {Buffer} key
+   */
+  static async createProof(trie: Trie, key: Buffer): Promise<Proof> {
     const { stack } = await trie.findPath(key)
     const p = stack.map((stackElem) => {
       return stackElem.serialize()
@@ -80,14 +102,18 @@ export class Trie {
     return p
   }
 
-  static async verifyProof(
-    rootHash: Buffer,
-    key: Buffer,
-    proofNodes: Buffer[],
-  ): Promise<Buffer | null> {
+  /**
+   * Verifies a proof.
+   * @param {Buffer} rootHash
+   * @param {Buffer} key
+   * @param {Proof} proof
+   * @throws If proof is found to be invalid.
+   * @returns The value from the key.
+   */
+  static async verifyProof(rootHash: Buffer, key: Buffer, proof: Proof): Promise<Buffer | null> {
     let proofTrie = new Trie(null, rootHash)
     try {
-      proofTrie = await Trie.fromProof(proofNodes, proofTrie)
+      proofTrie = await Trie.fromProof(proof, proofTrie)
     } catch (e) {
       throw new Error('Invalid proof nodes given')
     }
@@ -112,10 +138,8 @@ export class Trie {
 
   /**
    * Gets a value given a `key`
-   * @method get
-   * @memberof Trie
    * @param {Buffer} key - the key to search for
-   * @returns {Promise} - Returns a promise that resolves to `Buffer` if a value was found or `null` if no value was found.
+   * @returns A Promise that resolves to `Buffer` if a value was found or `null` if no value was found.
    */
   async get(key: Buffer): Promise<Buffer | null> {
     const { node, remaining } = await this.findPath(key)
@@ -127,12 +151,9 @@ export class Trie {
   }
 
   /**
-   * Stores a given `value` at the given `key`
-   * @method put
-   * @memberof Trie
+   * Stores a given `value` at the given `key`.
    * @param {Buffer} key
    * @param {Buffer} value
-   * @returns {Promise}
    */
   async put(key: Buffer, value: Buffer): Promise<void> {
     // If value is empty, delete
@@ -154,11 +175,8 @@ export class Trie {
   }
 
   /**
-   * deletes a value given a `key`
-   * @method del
-   * @memberof Trie
+   * Deletes a value given a `key`.
    * @param {Buffer} key
-   * @returns {Promise}
    */
   async del(key: Buffer): Promise<void> {
     await this.lock.wait()
@@ -169,7 +187,10 @@ export class Trie {
     this.lock.signal()
   }
 
-  // retrieves a node from dbs by hash
+  /**
+   * Retrieves a node from db by hash.
+   * @private
+   */
   async _lookupNode(node: Buffer | Buffer[]): Promise<TrieNode | null> {
     if (isRawNode(node)) {
       return decodeRawNode(node as Buffer[])
@@ -187,7 +208,10 @@ export class Trie {
     return foundNode
   }
 
-  // writes a single node to dbs
+  /**
+   * Writes a single node to db.
+   * @private
+   */
   async _putNode(node: TrieNode): Promise<void> {
     const hash = node.hash()
     const serialized = node.serialize()
@@ -197,10 +221,7 @@ export class Trie {
   /**
    * Tries to find a path to the node for the given key.
    * It returns a `stack` of nodes to the closet node.
-   * @method findPath
-   * @memberof Trie
    * @param {Buffer} key - the search key
-   * @returns {Promise}
    */
   async findPath(key: Buffer): Promise<Path> {
     return new Promise(async (resolve) => {
@@ -252,8 +273,9 @@ export class Trie {
     })
   }
 
-  /*
-   * Finds all nodes that store k,v values
+  /**
+   * Finds all nodes that store k,v values.
+   * @private
    */
   async _findValueNodes(onFound: FoundNode): Promise<void> {
     await this._walkTrie(this.root, async (nodeRef, node, key, walkController) => {
@@ -288,14 +310,12 @@ export class Trie {
   }
 
   /**
-   * Updates a node
-   * @method _updateNode
+   * Updates a node.
    * @private
    * @param {Buffer} key
    * @param {Buffer} value
    * @param {Nibbles} keyRemainder
    * @param {TrieNode[]} stack
-   * @returns {Promise}
    */
   async _updateNode(
     k: Buffer,
@@ -398,11 +418,10 @@ export class Trie {
 
   /**
    * Walks a trie until finished.
-   * @method _walkTrie
    * @private
    * @param {Buffer} root
    * @param {Function} onNode - callback to call when a node is found
-   * @returns {Promise} - returns when finished walking trie
+   * @returns Returns when finished walking trie.
    */
   async _walkTrie(root: Buffer, onNode: FoundNode): Promise<void> {
     return new Promise(async (resolve) => {
@@ -497,13 +516,11 @@ export class Trie {
   }
 
   /**
-   * saves a stack
-   * @method _saveStack
+   * Saves a stack.
    * @private
    * @param {Nibbles} key - the key. Should follow the stack
    * @param {Array} stack - a stack of nodes to the value given by the key
    * @param {Array} opStack - a stack of levelup operations to commit at the end of this funciton
-   * @returns {Promise}
    */
   async _saveStack(key: Nibbles, stack: TrieNode[], opStack: BatchDBOp[]): Promise<void> {
     let lastRoot
@@ -534,6 +551,10 @@ export class Trie {
     await this.db.batch(opStack)
   }
 
+  /**
+   * Deletes a node.
+   * @private
+   */
   async _deleteNode(k: Buffer, stack: TrieNode[]): Promise<void> {
     const processBranchNode = (
       key: Nibbles,
@@ -655,7 +676,10 @@ export class Trie {
     }
   }
 
-  // Creates the initial node from an empty tree
+  /**
+   * Creates the initial node from an empty tree.
+   * @private
+   */
   async _createInitialNode(key: Buffer, value: Buffer): Promise<void> {
     const newNode = new LeafNode(bufferToNibbles(key), value)
     this.root = newNode.hash()
@@ -663,14 +687,13 @@ export class Trie {
   }
 
   /**
-   * Formats node to be saved by levelup.batch.
-   * @method _formatNode
+   * Formats node to be saved by `levelup.batch`.
    * @private
-   * @param {TrieNode} node - the node to format
-   * @param {Boolean} topLevel - if the node is at the top level
-   * @param {BatchDBOp[]} opStack - the opStack to push the node's data
-   * @param {Boolean} remove - whether to remove the node (only used for CheckpointTrie)
-   * @returns {Buffer | (EmbeddedNode | null)[]} - the node's hash used as the key or the rawNode
+   * @param {TrieNode} node - the node to format.
+   * @param {Boolean} topLevel - if the node is at the top level.
+   * @param {BatchDBOp[]} opStack - the opStack to push the node's data.
+   * @param {Boolean} remove - whether to remove the node (only used for CheckpointTrie).
+   * @returns The node's hash used as the key or the rawNode.
    */
   _formatNode(
     node: TrieNode,
@@ -695,16 +718,15 @@ export class Trie {
 
   /**
    * The `data` event is given an `Object` that has two properties; the `key` and the `value`. Both should be Buffers.
-   * @method createReadStream
-   * @memberof Trie
-   * @return {stream.Readable} Returns a [stream](https://nodejs.org/dist/latest-v5.x/docs/api/stream.html#stream_class_stream_readable) of the contents of the `trie`
+   * @return {stream.Readable} Returns a [stream](https://nodejs.org/dist/latest-v12.x/docs/api/stream.html#stream_class_stream_readable) of the contents of the `trie`
    */
   createReadStream(): ReadStream {
     return new ReadStream(this)
   }
 
-  // creates a new trie backed by the same db
-  // and starting at the same root
+  /**
+   * Creates a new trie backed by the same db.
+   */
   copy(): Trie {
     const db = this.db.copy()
     return new Trie(db._leveldb, this.root)
@@ -712,8 +734,6 @@ export class Trie {
 
   /**
    * The given hash of operations (key additions or deletions) are executed on the DB
-   * @method batch
-   * @memberof Trie
    * @example
    * const ops = [
    *    { type: 'del', key: Buffer.from('father') }
@@ -724,7 +744,6 @@ export class Trie {
    * ]
    * await trie.batch(ops)
    * @param {Array} ops
-   * @returns {Promise}
    */
   async batch(ops: BatchDBOp[]): Promise<void> {
     for (const op of ops) {

--- a/src/checkpointTrie.ts
+++ b/src/checkpointTrie.ts
@@ -43,10 +43,8 @@ export class CheckpointTrie extends BaseTrie {
   }
 
   /**
-   * Commits a checkpoint to disk, if current checkpoint is not nested. If
-   * nested, only sets the parent checkpoint as current checkpoint.
-   * @method commit
-   * @returns {Promise}
+   * Commits a checkpoint to disk, if current checkpoint is not nested.
+   * If nested, only sets the parent checkpoint as current checkpoint.
    * @throws If not during a checkpoint phase
    */
   async commit(): Promise<void> {
@@ -127,7 +125,6 @@ export class CheckpointTrie extends BaseTrie {
   /**
    * Returns a `ScratchReadStream` based on the state updates
    * since checkpoint.
-   * @method createScratchReadStream
    * @private
    */
   _createScratchReadStream(scratchDb?: ScratchDB) {
@@ -141,14 +138,13 @@ export class CheckpointTrie extends BaseTrie {
   }
 
   /**
-   * Formats node to be saved by levelup.batch.
-   * @method _formatNode
+   * Formats node to be saved by `levelup.batch`.
    * @private
-   * @param {TrieNode} node - the node to format
-   * @param {Boolean} topLevel - if the node is at the top level
-   * @param {BatchDBOp[]} opStack - the opStack to push the node's data
-   * @param {Boolean} remove - whether to remove the node (only used for CheckpointTrie)
-   * @returns {Buffer | (EmbeddedNode | null)[]} - the node's hash used as the key or the rawNode
+   * @param {TrieNode} node - the node to format.
+   * @param {Boolean} topLevel - if the node is at the top level.
+   * @param {BatchDBOp[]} opStack - the opStack to push the node's data.
+   * @param {Boolean} remove - whether to remove the node (only used for CheckpointTrie).
+   * @returns The node's hash used as the key or the rawNode.
    */
   _formatNode(node: TrieNode, topLevel: boolean, opStack: BatchDBOp[], remove: boolean = false) {
     const rlpNode = node.serialize()

--- a/src/db.ts
+++ b/src/db.ts
@@ -33,7 +33,7 @@ export class DB {
   /**
    * Retrieves a raw value from leveldb.
    * @param {Buffer} key
-   * @returns {Promise} - Promise resolves with `Buffer` if a value is found or `null` if no value is found.
+   * @returns A Promise that resolves to `Buffer` if a value is found or `null` if no value is found.
    */
   async get(key: Buffer): Promise<Buffer | null> {
     let value = null

--- a/src/util/hex.ts
+++ b/src/util/hex.ts
@@ -2,7 +2,6 @@ import { Nibbles } from '../trieNode'
 
 /**
  * Prepends hex prefix to an array of nibbles.
- * @method addHexPrefix
  * @param {Nibbles} key - Array of nibbles
  * @returns {Nibbles} - returns buffer of encoded data
  **/
@@ -25,7 +24,6 @@ export function addHexPrefix(key: Nibbles, terminator: boolean): Nibbles {
 
 /**
  * Removes hex prefix of an array of nibbles.
- * @method removeHexPrefix
  * @param {Nibbles} val - Array of nibbles
  * @private
  */
@@ -41,7 +39,6 @@ export function removeHexPrefix(val: Nibbles): Nibbles {
 
 /**
  * Returns true if hex-prefixed path is for a terminating (leaf) node.
- * @method isTerminator
  * @param {Nibbles} key - a hex-prefixed array of nibbles
  * @private
  */

--- a/src/util/nibbles.ts
+++ b/src/util/nibbles.ts
@@ -2,9 +2,8 @@ import { Nibbles } from '../trieNode'
 
 /**
  * Converts a buffer to a nibble array.
- * @method bufferToNibbles
- * @param {Buffer} key
  * @private
+ * @param {Buffer} key
  */
 export function bufferToNibbles(key: Buffer): Nibbles {
   const bkey = Buffer.from(key)
@@ -22,9 +21,8 @@ export function bufferToNibbles(key: Buffer): Nibbles {
 
 /**
  * Converts a nibble array into a buffer.
- * @method nibblesToBuffer
- * @param {Nibbles} arr - Nibble array
  * @private
+ * @param {Nibbles} arr - Nibble array
  */
 export function nibblesToBuffer(arr: Nibbles): Buffer {
   let buf = Buffer.alloc(arr.length / 2)
@@ -37,10 +35,9 @@ export function nibblesToBuffer(arr: Nibbles): Buffer {
 
 /**
  * Returns the number of in order matching nibbles of two give nibble arrays.
- * @method matchingNibbleLength
+ * @private
  * @param {Nibbles} nib1
  * @param {Nibbles} nib2
- * @private
  */
 export function matchingNibbleLength(nib1: Nibbles, nib2: Nibbles): number {
   let i = 0

--- a/test/proof.spec.ts
+++ b/test/proof.spec.ts
@@ -11,27 +11,27 @@ tape('simple merkle proofs generation and verification', function (tester) {
     await trie.put(Buffer.from('key2bb'), Buffer.from('aval2'))
     await trie.put(Buffer.from('key3cc'), Buffer.from('aval3'))
 
-    let proof = await CheckpointTrie.prove(trie, Buffer.from('key2bb'))
+    let proof = await CheckpointTrie.createProof(trie, Buffer.from('key2bb'))
     let val = await CheckpointTrie.verifyProof(trie.root, Buffer.from('key2bb'), proof)
     t.equal(val!.toString('utf8'), 'aval2')
 
-    proof = await CheckpointTrie.prove(trie, Buffer.from('key1aa'))
+    proof = await CheckpointTrie.createProof(trie, Buffer.from('key1aa'))
     val = await CheckpointTrie.verifyProof(trie.root, Buffer.from('key1aa'), proof)
     t.equal(val!.toString('utf8'), '0123456789012345678901234567890123456789xx')
 
-    proof = await CheckpointTrie.prove(trie, Buffer.from('key2bb'))
+    proof = await CheckpointTrie.createProof(trie, Buffer.from('key2bb'))
     val = await CheckpointTrie.verifyProof(trie.root, Buffer.from('key2'), proof)
     // In this case, the proof _happens_ to contain enough nodes to prove `key2` because
     // traversing into `key22` would touch all the same nodes as traversing into `key2`
     t.equal(val, null, 'Expected value at a random key to be null')
 
     let myKey = Buffer.from('anyrandomkey')
-    proof = await CheckpointTrie.prove(trie, myKey)
+    proof = await CheckpointTrie.createProof(trie, myKey)
     val = await CheckpointTrie.verifyProof(trie.root, myKey, proof)
     t.equal(val, null, 'Expected value to be null')
 
     myKey = Buffer.from('anothergarbagekey') // should generate a valid proof of null
-    proof = await CheckpointTrie.prove(trie, myKey)
+    proof = await CheckpointTrie.createProof(trie, myKey)
     proof.push(Buffer.from('123456')) // extra nodes are just ignored
     val = await CheckpointTrie.verifyProof(trie.root, myKey, proof)
     t.equal(val, null, 'Expected value to be null')
@@ -39,7 +39,7 @@ tape('simple merkle proofs generation and verification', function (tester) {
     await trie.put(Buffer.from('another'), Buffer.from('3498h4riuhgwe'))
 
     // to fail our proof we can request a proof for one key
-    proof = await CheckpointTrie.prove(trie, Buffer.from('another'))
+    proof = await CheckpointTrie.createProof(trie, Buffer.from('another'))
     // and use that proof on another key
     const result = await CheckpointTrie.verifyProof(trie.root, Buffer.from('key1aa'), proof)
     t.equal(result, null)
@@ -51,7 +51,7 @@ tape('simple merkle proofs generation and verification', function (tester) {
 
     await trie.put(Buffer.from('key1aa'), Buffer.from('0123456789012345678901234567890123456789xx'))
 
-    const proof = await CheckpointTrie.prove(trie, Buffer.from('key1aa'))
+    const proof = await CheckpointTrie.createProof(trie, Buffer.from('key1aa'))
     const val = await CheckpointTrie.verifyProof(trie.root, Buffer.from('key1aa'), proof)
     t.equal(val!.toString('utf8'), '0123456789012345678901234567890123456789xx')
 
@@ -63,7 +63,7 @@ tape('simple merkle proofs generation and verification', function (tester) {
 
     await trie.put(Buffer.from('key1aa'), Buffer.from('01234'))
 
-    const proof = await CheckpointTrie.prove(trie, Buffer.from('key1aa'))
+    const proof = await CheckpointTrie.createProof(trie, Buffer.from('key1aa'))
     const val = await CheckpointTrie.verifyProof(trie.root, Buffer.from('key1aa'), proof)
     t.equal(val!.toString('utf8'), '01234')
 
@@ -86,15 +86,15 @@ tape('simple merkle proofs generation and verification', function (tester) {
     await trie.put(Buffer.from('key3cc'), Buffer.from('aval3'))
     await trie.put(Buffer.from('key3'), Buffer.from('1234567890123456789012345678901'))
 
-    let proof = await CheckpointTrie.prove(trie, Buffer.from('key1'))
+    let proof = await CheckpointTrie.createProof(trie, Buffer.from('key1'))
     let val = await CheckpointTrie.verifyProof(trie.root, Buffer.from('key1'), proof)
     t.equal(val!.toString('utf8'), '0123456789012345678901234567890123456789Very_Long')
 
-    proof = await CheckpointTrie.prove(trie, Buffer.from('key2'))
+    proof = await CheckpointTrie.createProof(trie, Buffer.from('key2'))
     val = await CheckpointTrie.verifyProof(trie.root, Buffer.from('key2'), proof)
     t.equal(val!.toString('utf8'), 'short')
 
-    proof = await CheckpointTrie.prove(trie, Buffer.from('key3'))
+    proof = await CheckpointTrie.createProof(trie, Buffer.from('key3'))
     val = await CheckpointTrie.verifyProof(trie.root, Buffer.from('key3'), proof)
     t.equal(val!.toString('utf8'), '1234567890123456789012345678901')
 
@@ -108,15 +108,15 @@ tape('simple merkle proofs generation and verification', function (tester) {
     await trie.put(Buffer.from('b'), Buffer.from('b'))
     await trie.put(Buffer.from('c'), Buffer.from('c'))
 
-    let proof = await CheckpointTrie.prove(trie, Buffer.from('a'))
+    let proof = await CheckpointTrie.createProof(trie, Buffer.from('a'))
     let val = await CheckpointTrie.verifyProof(trie.root, Buffer.from('a'), proof)
     t.equal(val!.toString('utf8'), 'a')
 
-    proof = await CheckpointTrie.prove(trie, Buffer.from('b'))
+    proof = await CheckpointTrie.createProof(trie, Buffer.from('b'))
     val = await CheckpointTrie.verifyProof(trie.root, Buffer.from('b'), proof)
     t.equal(val!.toString('utf8'), 'b')
 
-    proof = await CheckpointTrie.prove(trie, Buffer.from('c'))
+    proof = await CheckpointTrie.createProof(trie, Buffer.from('c'))
     val = await CheckpointTrie.verifyProof(trie.root, Buffer.from('c'), proof)
     t.equal(val!.toString('utf8'), 'c')
 

--- a/test/secure.spec.ts
+++ b/test/secure.spec.ts
@@ -25,7 +25,7 @@ tape('SecureTrie', function (t) {
       const trie = new SecureTrie()
       await trie.put(Buffer.from('key1aa'), Buffer.from('01234'))
 
-      const proof = await SecureTrie.prove(trie, Buffer.from('key1aa'))
+      const proof = await SecureTrie.createProof(trie, Buffer.from('key1aa'))
       const val = await SecureTrie.verifyProof(trie.root, Buffer.from('key1aa'), proof)
       st.equal(val!.toString('utf8'), '01234')
       st.end()

--- a/test/secure.spec.ts
+++ b/test/secure.spec.ts
@@ -134,7 +134,7 @@ tape('SecureTrie.copy', function (it) {
     await trie.put(Buffer.from('key2'), Buffer.from('value2'))
     const trieCopy = trie.copy()
     const value = await trieCopy.get(Buffer.from('key2'))
-    t.equal(value.toString(), 'value2')
+    t.equal(value!.toString(), 'value2')
     t.end()
   })
 
@@ -146,7 +146,7 @@ tape('SecureTrie.copy', function (it) {
     await trie.put(Buffer.from('key2'), Buffer.from('value2'))
     const trieCopy = trie.copy()
     const value = await trieCopy.get(Buffer.from('key1'))
-    t.equal(value.toString(), 'value1')
+    t.equal(value!.toString(), 'value1')
     t.end()
   })
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,5 @@
+{
+    "extends": "@ethereumjs/config-tsc",
+    "include": ["src/**/*.ts", "test/*.spec.ts"]
+}
+  

--- a/typedoc.json
+++ b/typedoc.json
@@ -5,7 +5,7 @@
   "plugin": "typedoc-plugin-markdown",
   "readme": "none",
   "gitRevision": "master",
-  "exclude": "src/**/!(secure|checkpointTrie|baseTrie).ts",
+  "exclude": ["src/**/!(secure|checkpointTrie|baseTrie).ts", "test/**/*.ts"],
   "excludeNotExported": true,
   "excludeExternals": true,
   "excludePrivate": true,


### PR DESCRIPTION
This PR:
  * Renames `prove` to `createProof`
    * Keeps `prove` as a deprecated alias
  * Introduces `type Proof = Buffer[]` to improve param types for `fromProof`, `createProof`, and `verifyProof`. 

Fixes #120

This PR also tidies up and adds some missing doc comments. In particular `@memberof` `@method` and `@returns {Promise}` are automatically understood so they don't need to be explicitly defined (see [Doc Comments syntax](https://typedoc.org/guides/doccomments/)).