### PR TITLE
Update readme references and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ async function test() {
 
 test()
 ```
+Additional examples with detailed explanations are available in [this repository](https://github.com/gabrocheleau/merkle-patricia-trees-examples).
 
 # API
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ async function test() {
 test()
 ```
 
-Additional examples with detailed explanations are available in [this repository](https://github.com/gabrocheleau/merkle-patricia-trees-examples).
+Additional examples with detailed explanations are available [here](https://github.com/gabrocheleau/merkle-patricia-trees-examples).
 
 # API
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ async function test() {
 
 test()
 ```
+
 Additional examples with detailed explanations are available in [this repository](https://github.com/gabrocheleau/merkle-patricia-trees-examples).
 
 # API

--- a/README.md
+++ b/README.md
@@ -131,9 +131,10 @@ test()
 - Wiki
   - [Ethereum Trie Specification](https://github.com/ethereum/wiki/wiki/Patricia-Tree)
 - Blog posts
+  - [Ethereum's Merkle Patricia Trees - An Interactive JavaScript Tutorial](https://rockwaterweb.com/ethereum-merkle-patricia-trees-javascript-tutorial/)
   - [Exploring Ethereum's State Trie with Node.js](https://wanderer.github.io/ethereum/nodejs/code/2014/05/21/using-ethereums-tries-with-node/)
   - [Merkling in Ethereum](https://blog.ethereum.org/2015/11/15/merkling-in-ethereum/)
-  - [Understanding the Ethereum Trie](https://easythereentropy.wordpress.com/2014/06/04/understanding-the-ethereum-trie/)
+  - [Understanding the Ethereum Trie (worth a read, but the code is outdated)](https://easythereentropy.wordpress.com/2014/06/04/understanding-the-ethereum-trie/)
 - Videos
   - [Trie and Patricia Trie Overview](https://www.youtube.com/watch?v=jXAHLqQthKw&t=26s)
 

--- a/README.md
+++ b/README.md
@@ -133,9 +133,8 @@ Additional examples with detailed explanations are available in [this repository
   - [Ethereum Trie Specification](https://github.com/ethereum/wiki/wiki/Patricia-Tree)
 - Blog posts
   - [Ethereum's Merkle Patricia Trees - An Interactive JavaScript Tutorial](https://rockwaterweb.com/ethereum-merkle-patricia-trees-javascript-tutorial/)
-  - [Exploring Ethereum's State Trie with Node.js](https://wanderer.github.io/ethereum/nodejs/code/2014/05/21/using-ethereums-tries-with-node/)
   - [Merkling in Ethereum](https://blog.ethereum.org/2015/11/15/merkling-in-ethereum/)
-  - [Understanding the Ethereum Trie (worth a read, but the code is outdated)](https://easythereentropy.wordpress.com/2014/06/04/understanding-the-ethereum-trie/)
+  - [Understanding the Ethereum Trie](https://easythereentropy.wordpress.com/2014/06/04/understanding-the-ethereum-trie/). Worth a read, but the Python libraries are outdated.
 - Videos
   - [Trie and Patricia Trie Overview](https://www.youtube.com/watch?v=jXAHLqQthKw&t=26s)
 


### PR DESCRIPTION
Added the [Merkle Patricia Trees tutorial](https://github.com/gabrocheleau/merkle-patricia-trees-examples) to the documentation, deleted the blog post with a 404 error and added a note for the blog post with outdated code.