### PR TITLE
Base trie code documentation and function clustering

### DIFF
--- a/docs/classes/_basetrie_.trie.md
+++ b/docs/classes/_basetrie_.trie.md
@@ -2,18 +2,9 @@
 
 # Class: Trie
 
-Use `import { BaseTrie as Trie } from 'merkle-patricia-tree'` for the base interface.
-In Ethereum applications stick with the Secure Trie Overlay `import { SecureTrie as Trie } from 'merkle-patricia-tree'`.
+The basic trie interface, use with `import { BaseTrie as Trie } from 'merkle-patricia-tree'`.
+In Ethereum applications stick with the [SecureTrie](_secure_.securetrie.md) overlay.
 The API for the base and the secure interface are about the same.
-
-**`param`** A [levelup](https://github.com/Level/levelup) instance. By default creates an in-memory [memdown](https://github.com/Level/memdown) instance.
-If the db is `null` or left undefined, then the trie will be stored in memory via [memdown](https://github.com/Level/memdown)
-
-**`param`** A `Buffer` for the root of a previously stored trie
-
-**`prop`** {Buffer} root - The current root of the `trie`
-
-**`prop`** {Buffer} EMPTY_TRIE_ROOT - The root for an empty trie
 
 ## Hierarchy
 
@@ -40,12 +31,12 @@ If the db is `null` or left undefined, then the trie will be stored in memory vi
 
 * [_createInitialNode](_basetrie_.trie.md#private-_createinitialnode)
 * [_deleteNode](_basetrie_.trie.md#private-_deletenode)
-* [_findDbNodes](_basetrie_.trie.md#_finddbnodes)
+* [_findDbNodes](_basetrie_.trie.md#private-_finddbnodes)
 * [_findValueNodes](_basetrie_.trie.md#private-_findvaluenodes)
 * [_formatNode](_basetrie_.trie.md#private-_formatnode)
 * [_lookupNode](_basetrie_.trie.md#private-_lookupnode)
-* [_putNode](_basetrie_.trie.md#private-_putnode)
 * [_saveStack](_basetrie_.trie.md#private-_savestack)
+* [_setRoot](_basetrie_.trie.md#_setroot)
 * [_updateNode](_basetrie_.trie.md#private-_updatenode)
 * [_walkTrie](_basetrie_.trie.md#private-_walktrie)
 * [batch](_basetrie_.trie.md#batch)
@@ -56,7 +47,6 @@ If the db is `null` or left undefined, then the trie will be stored in memory vi
 * [findPath](_basetrie_.trie.md#findpath)
 * [get](_basetrie_.trie.md#get)
 * [put](_basetrie_.trie.md#put)
-* [setRoot](_basetrie_.trie.md#setroot)
 * [createProof](_basetrie_.trie.md#static-createproof)
 * [fromProof](_basetrie_.trie.md#static-fromproof)
 * [prove](_basetrie_.trie.md#static-prove)
@@ -68,14 +58,16 @@ If the db is `null` or left undefined, then the trie will be stored in memory vi
 
 \+ **new Trie**(`db?`: LevelUp | null, `root?`: Buffer): *[Trie](_basetrie_.trie.md)*
 
-*Defined in [baseTrie.ts:45](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L45)*
+*Defined in [baseTrie.ts:47](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L47)*
+
+test
 
 **Parameters:**
 
-Name | Type |
------- | ------ |
-`db?` | LevelUp &#124; null |
-`root?` | Buffer |
+Name | Type | Description |
+------ | ------ | ------ |
+`db?` | LevelUp &#124; null | A [levelup](https://github.com/Level/levelup) instance. By default (if the db is `null` or left undefined) creates an in-memory [memdown](https://github.com/Level/memdown) instance. |
+`root?` | Buffer | A `Buffer` for the root of a previously stored trie  |
 
 **Returns:** *[Trie](_basetrie_.trie.md)*
 
@@ -85,7 +77,9 @@ Name | Type |
 
 • **EMPTY_TRIE_ROOT**: *Buffer*
 
-*Defined in [baseTrie.ts:42](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L42)*
+*Defined in [baseTrie.ts:45](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L45)*
+
+The root for an empty trie
 
 ___
 
@@ -95,19 +89,25 @@ ___
 
 *Defined in [baseTrie.ts:43](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L43)*
 
+The backend DB
+
 ## Accessors
 
 ###  root
 
 • **get root**(): *Buffer*
 
-*Defined in [baseTrie.ts:127](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L127)*
+*Defined in [baseTrie.ts:71](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L71)*
+
+Gets the current root of the `trie`
 
 **Returns:** *Buffer*
 
 • **set root**(`value`: Buffer): *void*
 
-*Defined in [baseTrie.ts:123](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L123)*
+*Defined in [baseTrie.ts:66](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L66)*
+
+Sets the current root of the `trie`
 
 **Parameters:**
 
@@ -123,7 +123,7 @@ Name | Type |
 
 ▸ **_createInitialNode**(`key`: Buffer, `value`: Buffer): *Promise‹void›*
 
-*Defined in [baseTrie.ts:683](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L683)*
+*Defined in [baseTrie.ts:304](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L304)*
 
 Creates the initial node from an empty tree.
 
@@ -142,9 +142,9 @@ ___
 
 ▸ **_deleteNode**(`k`: Buffer, `stack`: TrieNode[]): *Promise‹void›*
 
-*Defined in [baseTrie.ts:558](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L558)*
+*Defined in [baseTrie.ts:439](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L439)*
 
-Deletes a node.
+Deletes a node from the database.
 
 **Parameters:**
 
@@ -157,17 +157,21 @@ Name | Type |
 
 ___
 
-###  _findDbNodes
+### `Private` _findDbNodes
 
-▸ **_findDbNodes**(`onFound`: FoundNode): *Promise‹void›*
+▸ **_findDbNodes**(`onFound`: FoundNodeFunction): *Promise‹void›*
 
-*Defined in [baseTrie.ts:302](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L302)*
+*Defined in [baseTrie.ts:740](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L740)*
+
+Finds all nodes that are stored directly in the db
+(some nodes are stored raw inside other nodes)
+called by {@link ScratchReadStream}
 
 **Parameters:**
 
 Name | Type |
 ------ | ------ |
-`onFound` | FoundNode |
+`onFound` | FoundNodeFunction |
 
 **Returns:** *Promise‹void›*
 
@@ -175,17 +179,18 @@ ___
 
 ### `Private` _findValueNodes
 
-▸ **_findValueNodes**(`onFound`: FoundNode): *Promise‹void›*
+▸ **_findValueNodes**(`onFound`: FoundNodeFunction): *Promise‹void›*
 
-*Defined in [baseTrie.ts:280](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L280)*
+*Defined in [baseTrie.ts:756](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L756)*
 
-Finds all nodes that store k,v values.
+Finds all nodes that store k,v values
+called by {@link TrieReadStream}
 
 **Parameters:**
 
 Name | Type |
 ------ | ------ |
-`onFound` | FoundNode |
+`onFound` | FoundNodeFunction |
 
 **Returns:** *Promise‹void›*
 
@@ -195,7 +200,7 @@ ___
 
 ▸ **_formatNode**(`node`: TrieNode, `topLevel`: boolean, `opStack`: BatchDBOp[], `remove`: boolean): *Buffer | null | Buffer‹› | Buffer‹›[][]*
 
-*Defined in [baseTrie.ts:698](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L698)*
+*Defined in [baseTrie.ts:605](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L605)*
 
 Formats node to be saved by `levelup.batch`.
 
@@ -218,7 +223,7 @@ ___
 
 ▸ **_lookupNode**(`node`: Buffer | Buffer[]): *Promise‹TrieNode | null›*
 
-*Defined in [baseTrie.ts:194](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L194)*
+*Defined in [baseTrie.ts:314](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L314)*
 
 Retrieves a node from db by hash.
 
@@ -232,31 +237,13 @@ Name | Type |
 
 ___
 
-### `Private` _putNode
-
-▸ **_putNode**(`node`: TrieNode): *Promise‹void›*
-
-*Defined in [baseTrie.ts:215](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L215)*
-
-Writes a single node to db.
-
-**Parameters:**
-
-Name | Type |
------- | ------ |
-`node` | TrieNode |
-
-**Returns:** *Promise‹void›*
-
-___
-
 ### `Private` _saveStack
 
 ▸ **_saveStack**(`key`: Nibbles, `stack`: TrieNode[], `opStack`: BatchDBOp[]): *Promise‹void›*
 
-*Defined in [baseTrie.ts:525](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L525)*
+*Defined in [baseTrie.ts:567](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L567)*
 
-Saves a stack.
+Saves a stack of nodes to the database.
 
 **Parameters:**
 
@@ -270,11 +257,27 @@ Name | Type | Description |
 
 ___
 
+###  _setRoot
+
+▸ **_setRoot**(`value?`: Buffer): *void*
+
+*Defined in [baseTrie.ts:75](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L75)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value?` | Buffer |
+
+**Returns:** *void*
+
+___
+
 ### `Private` _updateNode
 
 ▸ **_updateNode**(`k`: Buffer, `value`: Buffer, `keyRemainder`: Nibbles, `stack`: TrieNode[]): *Promise‹void›*
 
-*Defined in [baseTrie.ts:320](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L320)*
+*Defined in [baseTrie.ts:336](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L336)*
 
 Updates a node.
 
@@ -293,9 +296,9 @@ ___
 
 ### `Private` _walkTrie
 
-▸ **_walkTrie**(`root`: Buffer, `onNode`: FoundNode): *Promise‹void›*
+▸ **_walkTrie**(`root`: Buffer, `onFound`: FoundNodeFunction): *Promise‹void›*
 
-*Defined in [baseTrie.ts:426](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L426)*
+*Defined in [baseTrie.ts:208](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L208)*
 
 Walks a trie until finished.
 
@@ -304,7 +307,7 @@ Walks a trie until finished.
 Name | Type | Description |
 ------ | ------ | ------ |
 `root` | Buffer | - |
-`onNode` | FoundNode | callback to call when a node is found |
+`onFound` | FoundNodeFunction | callback to call when a node is found |
 
 **Returns:** *Promise‹void›*
 
@@ -316,7 +319,7 @@ ___
 
 ▸ **batch**(`ops`: BatchDBOp[]): *Promise‹void›*
 
-*Defined in [baseTrie.ts:748](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L748)*
+*Defined in [baseTrie.ts:639](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L639)*
 
 The given hash of operations (key additions or deletions) are executed on the DB
 
@@ -344,7 +347,7 @@ ___
 
 ▸ **checkRoot**(`root`: Buffer): *Promise‹boolean›*
 
-*Defined in [baseTrie.ts:764](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L764)*
+*Defined in [baseTrie.ts:86](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L86)*
 
 Checks if a given root exists.
 
@@ -362,7 +365,7 @@ ___
 
 ▸ **copy**(): *[Trie](_basetrie_.trie.md)*
 
-*Defined in [baseTrie.ts:730](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L730)*
+*Defined in [baseTrie.ts:729](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L729)*
 
 Creates a new trie backed by the same db.
 
@@ -374,7 +377,7 @@ ___
 
 ▸ **createReadStream**(): *ReadStream*
 
-*Defined in [baseTrie.ts:723](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L723)*
+*Defined in [baseTrie.ts:722](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L722)*
 
 The `data` event is given an `Object` that has two properties; the `key` and the `value`. Both should be Buffers.
 
@@ -388,17 +391,19 @@ ___
 
 ▸ **del**(`key`: Buffer): *Promise‹void›*
 
-*Defined in [baseTrie.ts:181](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L181)*
+*Defined in [baseTrie.ts:135](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L135)*
 
 Deletes a value given a `key`.
 
 **Parameters:**
 
-Name | Type | Description |
------- | ------ | ------ |
-`key` | Buffer |   |
+Name | Type |
+------ | ------ |
+`key` | Buffer |
 
 **Returns:** *Promise‹void›*
+
+A Promise that resolves once value is deleted.
 
 ___
 
@@ -406,10 +411,10 @@ ___
 
 ▸ **findPath**(`key`: Buffer): *Promise‹Path›*
 
-*Defined in [baseTrie.ts:226](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L226)*
+*Defined in [baseTrie.ts:149](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L149)*
 
 Tries to find a path to the node for the given key.
-It returns a `stack` of nodes to the closet node.
+It returns a `stack` of nodes to the closest node.
 
 **Parameters:**
 
@@ -425,7 +430,7 @@ ___
 
 ▸ **get**(`key`: Buffer): *Promise‹Buffer | null›*
 
-*Defined in [baseTrie.ts:144](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L144)*
+*Defined in [baseTrie.ts:96](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L96)*
 
 Gets a value given a `key`
 
@@ -445,34 +450,20 @@ ___
 
 ▸ **put**(`key`: Buffer, `value`: Buffer): *Promise‹void›*
 
-*Defined in [baseTrie.ts:158](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L158)*
+*Defined in [baseTrie.ts:111](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L111)*
 
 Stores a given `value` at the given `key`.
 
 **Parameters:**
 
-Name | Type | Description |
------- | ------ | ------ |
-`key` | Buffer | - |
-`value` | Buffer |   |
+Name | Type |
+------ | ------ |
+`key` | Buffer |
+`value` | Buffer |
 
 **Returns:** *Promise‹void›*
 
-___
-
-###  setRoot
-
-▸ **setRoot**(`value?`: Buffer): *void*
-
-*Defined in [baseTrie.ts:131](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L131)*
-
-**Parameters:**
-
-Name | Type |
------- | ------ |
-`value?` | Buffer |
-
-**Returns:** *void*
+A Promise that resolves once value is stored.
 
 ___
 
@@ -480,7 +471,7 @@ ___
 
 ▸ **createProof**(`trie`: [Trie](_basetrie_.trie.md), `key`: Buffer): *Promise‹[Proof](../modules/_basetrie_.md#proof)›*
 
-*Defined in [baseTrie.ts:97](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L97)*
+*Defined in [baseTrie.ts:692](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L692)*
 
 Creates a proof from a trie and key that can be verified using [Trie.verifyProof](_basetrie_.trie.md#static-verifyproof).
 
@@ -499,7 +490,7 @@ ___
 
 ▸ **fromProof**(`proof`: [Proof](../modules/_basetrie_.md#proof), `trie?`: [Trie](_basetrie_.trie.md)): *Promise‹[Trie](_basetrie_.trie.md)›*
 
-*Defined in [baseTrie.ts:62](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L62)*
+*Defined in [baseTrie.ts:657](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L657)*
 
 Saves the nodes from a proof into the trie. If no trie is provided a new one wil be instantiated.
 
@@ -518,7 +509,7 @@ ___
 
 ▸ **prove**(`trie`: [Trie](_basetrie_.trie.md), `key`: Buffer): *Promise‹[Proof](../modules/_basetrie_.md#proof)›*
 
-*Defined in [baseTrie.ts:88](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L88)*
+*Defined in [baseTrie.ts:683](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L683)*
 
 prove has been renamed to [Trie.createProof](_basetrie_.trie.md#static-createproof).
 
@@ -539,7 +530,7 @@ ___
 
 ▸ **verifyProof**(`rootHash`: Buffer, `key`: Buffer, `proof`: [Proof](../modules/_basetrie_.md#proof)): *Promise‹Buffer | null›*
 
-*Defined in [baseTrie.ts:113](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L113)*
+*Defined in [baseTrie.ts:708](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L708)*
 
 Verifies a proof.
 

--- a/docs/classes/_checkpointtrie_.checkpointtrie.md
+++ b/docs/classes/_checkpointtrie_.checkpointtrie.md
@@ -2,6 +2,8 @@
 
 # Class: CheckpointTrie
 
+Adds checkpointing to the {@link BaseTrie}
+
 ## Hierarchy
 
 * [Trie](_basetrie_.trie.md)
@@ -36,12 +38,12 @@
 * [_deleteNode](_checkpointtrie_.checkpointtrie.md#private-_deletenode)
 * [_enterCpMode](_checkpointtrie_.checkpointtrie.md#private-_entercpmode)
 * [_exitCpMode](_checkpointtrie_.checkpointtrie.md#private-_exitcpmode)
-* [_findDbNodes](_checkpointtrie_.checkpointtrie.md#_finddbnodes)
+* [_findDbNodes](_checkpointtrie_.checkpointtrie.md#private-_finddbnodes)
 * [_findValueNodes](_checkpointtrie_.checkpointtrie.md#private-_findvaluenodes)
 * [_formatNode](_checkpointtrie_.checkpointtrie.md#private-_formatnode)
 * [_lookupNode](_checkpointtrie_.checkpointtrie.md#private-_lookupnode)
-* [_putNode](_checkpointtrie_.checkpointtrie.md#private-_putnode)
 * [_saveStack](_checkpointtrie_.checkpointtrie.md#private-_savestack)
+* [_setRoot](_checkpointtrie_.checkpointtrie.md#_setroot)
 * [_updateNode](_checkpointtrie_.checkpointtrie.md#private-_updatenode)
 * [_walkTrie](_checkpointtrie_.checkpointtrie.md#private-_walktrie)
 * [batch](_checkpointtrie_.checkpointtrie.md#batch)
@@ -55,7 +57,6 @@
 * [get](_checkpointtrie_.checkpointtrie.md#get)
 * [put](_checkpointtrie_.checkpointtrie.md#put)
 * [revert](_checkpointtrie_.checkpointtrie.md#revert)
-* [setRoot](_checkpointtrie_.checkpointtrie.md#setroot)
 * [createProof](_checkpointtrie_.checkpointtrie.md#static-createproof)
 * [fromProof](_checkpointtrie_.checkpointtrie.md#static-fromproof)
 * [prove](_checkpointtrie_.checkpointtrie.md#static-prove)
@@ -69,7 +70,7 @@
 
 *Overrides [Trie](_basetrie_.trie.md).[constructor](_basetrie_.trie.md#constructor)*
 
-*Defined in [checkpointTrie.ts:11](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/checkpointTrie.ts#L11)*
+*Defined in [checkpointTrie.ts:14](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/checkpointTrie.ts#L14)*
 
 **Parameters:**
 
@@ -87,7 +88,9 @@ Name | Type |
 
 *Inherited from [Trie](_basetrie_.trie.md).[EMPTY_TRIE_ROOT](_basetrie_.trie.md#empty_trie_root)*
 
-*Defined in [baseTrie.ts:42](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L42)*
+*Defined in [baseTrie.ts:45](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L45)*
+
+The root for an empty trie
 
 ___
 
@@ -95,7 +98,7 @@ ___
 
 • **_checkpoints**: *Buffer[]*
 
-*Defined in [checkpointTrie.ts:11](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/checkpointTrie.ts#L11)*
+*Defined in [checkpointTrie.ts:14](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/checkpointTrie.ts#L14)*
 
 ___
 
@@ -103,7 +106,7 @@ ___
 
 • **_mainDB**: *DB*
 
-*Defined in [checkpointTrie.ts:9](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/checkpointTrie.ts#L9)*
+*Defined in [checkpointTrie.ts:12](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/checkpointTrie.ts#L12)*
 
 ___
 
@@ -111,7 +114,7 @@ ___
 
 • **_scratch**: *ScratchDB | null*
 
-*Defined in [checkpointTrie.ts:10](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/checkpointTrie.ts#L10)*
+*Defined in [checkpointTrie.ts:13](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/checkpointTrie.ts#L13)*
 
 ___
 
@@ -123,13 +126,15 @@ ___
 
 *Defined in [baseTrie.ts:43](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L43)*
 
+The backend DB
+
 ## Accessors
 
 ###  isCheckpoint
 
 • **get isCheckpoint**(): *boolean*
 
-*Defined in [checkpointTrie.ts:26](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/checkpointTrie.ts#L26)*
+*Defined in [checkpointTrie.ts:29](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/checkpointTrie.ts#L29)*
 
 Is the trie during a checkpoint phase?
 
@@ -143,7 +148,9 @@ ___
 
 *Inherited from [Trie](_basetrie_.trie.md).[root](_basetrie_.trie.md#root)*
 
-*Defined in [baseTrie.ts:127](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L127)*
+*Defined in [baseTrie.ts:71](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L71)*
+
+Gets the current root of the `trie`
 
 **Returns:** *Buffer*
 
@@ -151,7 +158,9 @@ ___
 
 *Inherited from [Trie](_basetrie_.trie.md).[root](_basetrie_.trie.md#root)*
 
-*Defined in [baseTrie.ts:123](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L123)*
+*Defined in [baseTrie.ts:66](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L66)*
+
+Sets the current root of the `trie`
 
 **Parameters:**
 
@@ -169,7 +178,7 @@ Name | Type |
 
 *Inherited from [Trie](_basetrie_.trie.md).[_createInitialNode](_basetrie_.trie.md#private-_createinitialnode)*
 
-*Defined in [baseTrie.ts:683](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L683)*
+*Defined in [baseTrie.ts:304](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L304)*
 
 Creates the initial node from an empty tree.
 
@@ -188,7 +197,7 @@ ___
 
 ▸ **_createScratchReadStream**(`scratchDb?`: ScratchDB): *ScratchReadStream‹›*
 
-*Defined in [checkpointTrie.ts:130](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/checkpointTrie.ts#L130)*
+*Defined in [checkpointTrie.ts:133](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/checkpointTrie.ts#L133)*
 
 Returns a `ScratchReadStream` based on the state updates
 since checkpoint.
@@ -209,9 +218,9 @@ ___
 
 *Inherited from [Trie](_basetrie_.trie.md).[_deleteNode](_basetrie_.trie.md#private-_deletenode)*
 
-*Defined in [baseTrie.ts:558](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L558)*
+*Defined in [baseTrie.ts:439](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L439)*
 
-Deletes a node.
+Deletes a node from the database.
 
 **Parameters:**
 
@@ -228,7 +237,7 @@ ___
 
 ▸ **_enterCpMode**(): *void*
 
-*Defined in [checkpointTrie.ts:100](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/checkpointTrie.ts#L100)*
+*Defined in [checkpointTrie.ts:103](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/checkpointTrie.ts#L103)*
 
 Enter into checkpoint mode.
 
@@ -240,7 +249,7 @@ ___
 
 ▸ **_exitCpMode**(`commitState`: boolean): *Promise‹void›*
 
-*Defined in [checkpointTrie.ts:109](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/checkpointTrie.ts#L109)*
+*Defined in [checkpointTrie.ts:112](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/checkpointTrie.ts#L112)*
 
 Exit from checkpoint mode.
 
@@ -254,19 +263,23 @@ Name | Type |
 
 ___
 
-###  _findDbNodes
+### `Private` _findDbNodes
 
-▸ **_findDbNodes**(`onFound`: FoundNode): *Promise‹void›*
+▸ **_findDbNodes**(`onFound`: FoundNodeFunction): *Promise‹void›*
 
-*Inherited from [Trie](_basetrie_.trie.md).[_findDbNodes](_basetrie_.trie.md#_finddbnodes)*
+*Inherited from [Trie](_basetrie_.trie.md).[_findDbNodes](_basetrie_.trie.md#private-_finddbnodes)*
 
-*Defined in [baseTrie.ts:302](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L302)*
+*Defined in [baseTrie.ts:740](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L740)*
+
+Finds all nodes that are stored directly in the db
+(some nodes are stored raw inside other nodes)
+called by {@link ScratchReadStream}
 
 **Parameters:**
 
 Name | Type |
 ------ | ------ |
-`onFound` | FoundNode |
+`onFound` | FoundNodeFunction |
 
 **Returns:** *Promise‹void›*
 
@@ -274,19 +287,20 @@ ___
 
 ### `Private` _findValueNodes
 
-▸ **_findValueNodes**(`onFound`: FoundNode): *Promise‹void›*
+▸ **_findValueNodes**(`onFound`: FoundNodeFunction): *Promise‹void›*
 
 *Inherited from [Trie](_basetrie_.trie.md).[_findValueNodes](_basetrie_.trie.md#private-_findvaluenodes)*
 
-*Defined in [baseTrie.ts:280](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L280)*
+*Defined in [baseTrie.ts:756](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L756)*
 
-Finds all nodes that store k,v values.
+Finds all nodes that store k,v values
+called by {@link TrieReadStream}
 
 **Parameters:**
 
 Name | Type |
 ------ | ------ |
-`onFound` | FoundNode |
+`onFound` | FoundNodeFunction |
 
 **Returns:** *Promise‹void›*
 
@@ -298,7 +312,7 @@ ___
 
 *Overrides [Trie](_basetrie_.trie.md).[_formatNode](_basetrie_.trie.md#private-_formatnode)*
 
-*Defined in [checkpointTrie.ts:149](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/checkpointTrie.ts#L149)*
+*Defined in [checkpointTrie.ts:152](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/checkpointTrie.ts#L152)*
 
 Formats node to be saved by `levelup.batch`.
 
@@ -323,7 +337,7 @@ ___
 
 *Inherited from [Trie](_basetrie_.trie.md).[_lookupNode](_basetrie_.trie.md#private-_lookupnode)*
 
-*Defined in [baseTrie.ts:194](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L194)*
+*Defined in [baseTrie.ts:314](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L314)*
 
 Retrieves a node from db by hash.
 
@@ -337,35 +351,15 @@ Name | Type |
 
 ___
 
-### `Private` _putNode
-
-▸ **_putNode**(`node`: TrieNode): *Promise‹void›*
-
-*Inherited from [Trie](_basetrie_.trie.md).[_putNode](_basetrie_.trie.md#private-_putnode)*
-
-*Defined in [baseTrie.ts:215](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L215)*
-
-Writes a single node to db.
-
-**Parameters:**
-
-Name | Type |
------- | ------ |
-`node` | TrieNode |
-
-**Returns:** *Promise‹void›*
-
-___
-
 ### `Private` _saveStack
 
 ▸ **_saveStack**(`key`: Nibbles, `stack`: TrieNode[], `opStack`: BatchDBOp[]): *Promise‹void›*
 
 *Inherited from [Trie](_basetrie_.trie.md).[_saveStack](_basetrie_.trie.md#private-_savestack)*
 
-*Defined in [baseTrie.ts:525](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L525)*
+*Defined in [baseTrie.ts:567](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L567)*
 
-Saves a stack.
+Saves a stack of nodes to the database.
 
 **Parameters:**
 
@@ -379,13 +373,31 @@ Name | Type | Description |
 
 ___
 
+###  _setRoot
+
+▸ **_setRoot**(`value?`: Buffer): *void*
+
+*Inherited from [Trie](_basetrie_.trie.md).[_setRoot](_basetrie_.trie.md#_setroot)*
+
+*Defined in [baseTrie.ts:75](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L75)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value?` | Buffer |
+
+**Returns:** *void*
+
+___
+
 ### `Private` _updateNode
 
 ▸ **_updateNode**(`k`: Buffer, `value`: Buffer, `keyRemainder`: Nibbles, `stack`: TrieNode[]): *Promise‹void›*
 
 *Inherited from [Trie](_basetrie_.trie.md).[_updateNode](_basetrie_.trie.md#private-_updatenode)*
 
-*Defined in [baseTrie.ts:320](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L320)*
+*Defined in [baseTrie.ts:336](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L336)*
 
 Updates a node.
 
@@ -404,11 +416,11 @@ ___
 
 ### `Private` _walkTrie
 
-▸ **_walkTrie**(`root`: Buffer, `onNode`: FoundNode): *Promise‹void›*
+▸ **_walkTrie**(`root`: Buffer, `onFound`: FoundNodeFunction): *Promise‹void›*
 
 *Inherited from [Trie](_basetrie_.trie.md).[_walkTrie](_basetrie_.trie.md#private-_walktrie)*
 
-*Defined in [baseTrie.ts:426](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L426)*
+*Defined in [baseTrie.ts:208](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L208)*
 
 Walks a trie until finished.
 
@@ -417,7 +429,7 @@ Walks a trie until finished.
 Name | Type | Description |
 ------ | ------ | ------ |
 `root` | Buffer | - |
-`onNode` | FoundNode | callback to call when a node is found |
+`onFound` | FoundNodeFunction | callback to call when a node is found |
 
 **Returns:** *Promise‹void›*
 
@@ -431,7 +443,7 @@ ___
 
 *Inherited from [Trie](_basetrie_.trie.md).[batch](_basetrie_.trie.md#batch)*
 
-*Defined in [baseTrie.ts:748](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L748)*
+*Defined in [baseTrie.ts:639](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L639)*
 
 The given hash of operations (key additions or deletions) are executed on the DB
 
@@ -461,7 +473,7 @@ ___
 
 *Inherited from [Trie](_basetrie_.trie.md).[checkRoot](_basetrie_.trie.md#checkroot)*
 
-*Defined in [baseTrie.ts:764](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L764)*
+*Defined in [baseTrie.ts:86](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L86)*
 
 Checks if a given root exists.
 
@@ -479,7 +491,7 @@ ___
 
 ▸ **checkpoint**(): *void*
 
-*Defined in [checkpointTrie.ts:35](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/checkpointTrie.ts#L35)*
+*Defined in [checkpointTrie.ts:38](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/checkpointTrie.ts#L38)*
 
 Creates a checkpoint that can later be reverted to or committed.
 After this is called, no changes to the trie will be permanently saved until `commit` is called.
@@ -493,7 +505,7 @@ ___
 
 ▸ **commit**(): *Promise‹void›*
 
-*Defined in [checkpointTrie.ts:50](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/checkpointTrie.ts#L50)*
+*Defined in [checkpointTrie.ts:53](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/checkpointTrie.ts#L53)*
 
 Commits a checkpoint to disk, if current checkpoint is not nested.
 If nested, only sets the parent checkpoint as current checkpoint.
@@ -510,7 +522,7 @@ ___
 
 *Overrides [Trie](_basetrie_.trie.md).[copy](_basetrie_.trie.md#copy)*
 
-*Defined in [checkpointTrie.ts:85](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/checkpointTrie.ts#L85)*
+*Defined in [checkpointTrie.ts:88](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/checkpointTrie.ts#L88)*
 
 Returns a copy of the underlying trie with the interface of CheckpointTrie.
 
@@ -530,7 +542,7 @@ ___
 
 *Inherited from [Trie](_basetrie_.trie.md).[createReadStream](_basetrie_.trie.md#createreadstream)*
 
-*Defined in [baseTrie.ts:723](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L723)*
+*Defined in [baseTrie.ts:722](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L722)*
 
 The `data` event is given an `Object` that has two properties; the `key` and the `value`. Both should be Buffers.
 
@@ -546,17 +558,19 @@ ___
 
 *Inherited from [Trie](_basetrie_.trie.md).[del](_basetrie_.trie.md#del)*
 
-*Defined in [baseTrie.ts:181](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L181)*
+*Defined in [baseTrie.ts:135](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L135)*
 
 Deletes a value given a `key`.
 
 **Parameters:**
 
-Name | Type | Description |
------- | ------ | ------ |
-`key` | Buffer |   |
+Name | Type |
+------ | ------ |
+`key` | Buffer |
 
 **Returns:** *Promise‹void›*
+
+A Promise that resolves once value is deleted.
 
 ___
 
@@ -566,10 +580,10 @@ ___
 
 *Inherited from [Trie](_basetrie_.trie.md).[findPath](_basetrie_.trie.md#findpath)*
 
-*Defined in [baseTrie.ts:226](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L226)*
+*Defined in [baseTrie.ts:149](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L149)*
 
 Tries to find a path to the node for the given key.
-It returns a `stack` of nodes to the closet node.
+It returns a `stack` of nodes to the closest node.
 
 **Parameters:**
 
@@ -587,7 +601,7 @@ ___
 
 *Inherited from [Trie](_basetrie_.trie.md).[get](_basetrie_.trie.md#get)*
 
-*Defined in [baseTrie.ts:144](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L144)*
+*Defined in [baseTrie.ts:96](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L96)*
 
 Gets a value given a `key`
 
@@ -609,18 +623,20 @@ ___
 
 *Inherited from [Trie](_basetrie_.trie.md).[put](_basetrie_.trie.md#put)*
 
-*Defined in [baseTrie.ts:158](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L158)*
+*Defined in [baseTrie.ts:111](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L111)*
 
 Stores a given `value` at the given `key`.
 
 **Parameters:**
 
-Name | Type | Description |
------- | ------ | ------ |
-`key` | Buffer | - |
-`value` | Buffer |   |
+Name | Type |
+------ | ------ |
+`key` | Buffer |
+`value` | Buffer |
 
 **Returns:** *Promise‹void›*
+
+A Promise that resolves once value is stored.
 
 ___
 
@@ -628,7 +644,7 @@ ___
 
 ▸ **revert**(): *Promise‹void›*
 
-*Defined in [checkpointTrie.ts:70](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/checkpointTrie.ts#L70)*
+*Defined in [checkpointTrie.ts:73](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/checkpointTrie.ts#L73)*
 
 Reverts the trie to the state it was at when `checkpoint` was first called.
 If during a nested checkpoint, sets root to most recent checkpoint, and sets
@@ -638,31 +654,13 @@ parent checkpoint as current.
 
 ___
 
-###  setRoot
-
-▸ **setRoot**(`value?`: Buffer): *void*
-
-*Inherited from [Trie](_basetrie_.trie.md).[setRoot](_basetrie_.trie.md#setroot)*
-
-*Defined in [baseTrie.ts:131](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L131)*
-
-**Parameters:**
-
-Name | Type |
------- | ------ |
-`value?` | Buffer |
-
-**Returns:** *void*
-
-___
-
 ### `Static` createProof
 
 ▸ **createProof**(`trie`: [Trie](_basetrie_.trie.md), `key`: Buffer): *Promise‹[Proof](../modules/_basetrie_.md#proof)›*
 
 *Inherited from [Trie](_basetrie_.trie.md).[createProof](_basetrie_.trie.md#static-createproof)*
 
-*Defined in [baseTrie.ts:97](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L97)*
+*Defined in [baseTrie.ts:692](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L692)*
 
 Creates a proof from a trie and key that can be verified using [Trie.verifyProof](_basetrie_.trie.md#static-verifyproof).
 
@@ -683,7 +681,7 @@ ___
 
 *Inherited from [Trie](_basetrie_.trie.md).[fromProof](_basetrie_.trie.md#static-fromproof)*
 
-*Defined in [baseTrie.ts:62](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L62)*
+*Defined in [baseTrie.ts:657](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L657)*
 
 Saves the nodes from a proof into the trie. If no trie is provided a new one wil be instantiated.
 
@@ -704,7 +702,7 @@ ___
 
 *Inherited from [Trie](_basetrie_.trie.md).[prove](_basetrie_.trie.md#static-prove)*
 
-*Defined in [baseTrie.ts:88](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L88)*
+*Defined in [baseTrie.ts:683](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L683)*
 
 prove has been renamed to [Trie.createProof](_basetrie_.trie.md#static-createproof).
 
@@ -727,7 +725,7 @@ ___
 
 *Inherited from [Trie](_basetrie_.trie.md).[verifyProof](_basetrie_.trie.md#static-verifyproof)*
 
-*Defined in [baseTrie.ts:113](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L113)*
+*Defined in [baseTrie.ts:708](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L708)*
 
 Verifies a proof.
 

--- a/docs/classes/_secure_.securetrie.md
+++ b/docs/classes/_secure_.securetrie.md
@@ -3,7 +3,7 @@
 # Class: SecureTrie
 
 You can create a secure Trie where the keys are automatically hashed
-using **keccak256** by using `require('merkle-patricia-tree').SecureTrie`.
+using **keccak256** by using `import { SecureTrie as Trie } from 'merkle-patricia-tree'`.
 It has the same methods and constructor as `Trie`.
 
 **`class`** SecureTrie
@@ -42,12 +42,12 @@ It has the same methods and constructor as `Trie`.
 * [_deleteNode](_secure_.securetrie.md#private-_deletenode)
 * [_enterCpMode](_secure_.securetrie.md#private-_entercpmode)
 * [_exitCpMode](_secure_.securetrie.md#private-_exitcpmode)
-* [_findDbNodes](_secure_.securetrie.md#_finddbnodes)
+* [_findDbNodes](_secure_.securetrie.md#private-_finddbnodes)
 * [_findValueNodes](_secure_.securetrie.md#private-_findvaluenodes)
 * [_formatNode](_secure_.securetrie.md#private-_formatnode)
 * [_lookupNode](_secure_.securetrie.md#private-_lookupnode)
-* [_putNode](_secure_.securetrie.md#private-_putnode)
 * [_saveStack](_secure_.securetrie.md#private-_savestack)
+* [_setRoot](_secure_.securetrie.md#_setroot)
 * [_updateNode](_secure_.securetrie.md#private-_updatenode)
 * [_walkTrie](_secure_.securetrie.md#private-_walktrie)
 * [batch](_secure_.securetrie.md#batch)
@@ -61,7 +61,6 @@ It has the same methods and constructor as `Trie`.
 * [get](_secure_.securetrie.md#get)
 * [put](_secure_.securetrie.md#put)
 * [revert](_secure_.securetrie.md#revert)
-* [setRoot](_secure_.securetrie.md#setroot)
 * [createProof](_secure_.securetrie.md#static-createproof)
 * [fromProof](_secure_.securetrie.md#static-fromproof)
 * [prove](_secure_.securetrie.md#static-prove)
@@ -93,7 +92,9 @@ Name | Type |
 
 *Inherited from [Trie](_basetrie_.trie.md).[EMPTY_TRIE_ROOT](_basetrie_.trie.md#empty_trie_root)*
 
-*Defined in [baseTrie.ts:42](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L42)*
+*Defined in [baseTrie.ts:45](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L45)*
+
+The root for an empty trie
 
 ___
 
@@ -103,7 +104,7 @@ ___
 
 *Inherited from [CheckpointTrie](_checkpointtrie_.checkpointtrie.md).[_checkpoints](_checkpointtrie_.checkpointtrie.md#_checkpoints)*
 
-*Defined in [checkpointTrie.ts:11](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/checkpointTrie.ts#L11)*
+*Defined in [checkpointTrie.ts:14](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/checkpointTrie.ts#L14)*
 
 ___
 
@@ -113,7 +114,7 @@ ___
 
 *Inherited from [CheckpointTrie](_checkpointtrie_.checkpointtrie.md).[_mainDB](_checkpointtrie_.checkpointtrie.md#_maindb)*
 
-*Defined in [checkpointTrie.ts:9](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/checkpointTrie.ts#L9)*
+*Defined in [checkpointTrie.ts:12](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/checkpointTrie.ts#L12)*
 
 ___
 
@@ -123,7 +124,7 @@ ___
 
 *Inherited from [CheckpointTrie](_checkpointtrie_.checkpointtrie.md).[_scratch](_checkpointtrie_.checkpointtrie.md#_scratch)*
 
-*Defined in [checkpointTrie.ts:10](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/checkpointTrie.ts#L10)*
+*Defined in [checkpointTrie.ts:13](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/checkpointTrie.ts#L13)*
 
 ___
 
@@ -135,6 +136,8 @@ ___
 
 *Defined in [baseTrie.ts:43](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L43)*
 
+The backend DB
+
 ## Accessors
 
 ###  isCheckpoint
@@ -143,7 +146,7 @@ ___
 
 *Inherited from [CheckpointTrie](_checkpointtrie_.checkpointtrie.md).[isCheckpoint](_checkpointtrie_.checkpointtrie.md#ischeckpoint)*
 
-*Defined in [checkpointTrie.ts:26](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/checkpointTrie.ts#L26)*
+*Defined in [checkpointTrie.ts:29](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/checkpointTrie.ts#L29)*
 
 Is the trie during a checkpoint phase?
 
@@ -157,7 +160,9 @@ ___
 
 *Inherited from [Trie](_basetrie_.trie.md).[root](_basetrie_.trie.md#root)*
 
-*Defined in [baseTrie.ts:127](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L127)*
+*Defined in [baseTrie.ts:71](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L71)*
+
+Gets the current root of the `trie`
 
 **Returns:** *Buffer*
 
@@ -165,7 +170,9 @@ ___
 
 *Inherited from [Trie](_basetrie_.trie.md).[root](_basetrie_.trie.md#root)*
 
-*Defined in [baseTrie.ts:123](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L123)*
+*Defined in [baseTrie.ts:66](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L66)*
+
+Sets the current root of the `trie`
 
 **Parameters:**
 
@@ -183,7 +190,7 @@ Name | Type |
 
 *Inherited from [Trie](_basetrie_.trie.md).[_createInitialNode](_basetrie_.trie.md#private-_createinitialnode)*
 
-*Defined in [baseTrie.ts:683](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L683)*
+*Defined in [baseTrie.ts:304](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L304)*
 
 Creates the initial node from an empty tree.
 
@@ -204,7 +211,7 @@ ___
 
 *Inherited from [CheckpointTrie](_checkpointtrie_.checkpointtrie.md).[_createScratchReadStream](_checkpointtrie_.checkpointtrie.md#private-_createscratchreadstream)*
 
-*Defined in [checkpointTrie.ts:130](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/checkpointTrie.ts#L130)*
+*Defined in [checkpointTrie.ts:133](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/checkpointTrie.ts#L133)*
 
 Returns a `ScratchReadStream` based on the state updates
 since checkpoint.
@@ -225,9 +232,9 @@ ___
 
 *Inherited from [Trie](_basetrie_.trie.md).[_deleteNode](_basetrie_.trie.md#private-_deletenode)*
 
-*Defined in [baseTrie.ts:558](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L558)*
+*Defined in [baseTrie.ts:439](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L439)*
 
-Deletes a node.
+Deletes a node from the database.
 
 **Parameters:**
 
@@ -246,7 +253,7 @@ ___
 
 *Inherited from [CheckpointTrie](_checkpointtrie_.checkpointtrie.md).[_enterCpMode](_checkpointtrie_.checkpointtrie.md#private-_entercpmode)*
 
-*Defined in [checkpointTrie.ts:100](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/checkpointTrie.ts#L100)*
+*Defined in [checkpointTrie.ts:103](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/checkpointTrie.ts#L103)*
 
 Enter into checkpoint mode.
 
@@ -260,7 +267,7 @@ ___
 
 *Inherited from [CheckpointTrie](_checkpointtrie_.checkpointtrie.md).[_exitCpMode](_checkpointtrie_.checkpointtrie.md#private-_exitcpmode)*
 
-*Defined in [checkpointTrie.ts:109](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/checkpointTrie.ts#L109)*
+*Defined in [checkpointTrie.ts:112](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/checkpointTrie.ts#L112)*
 
 Exit from checkpoint mode.
 
@@ -274,19 +281,23 @@ Name | Type |
 
 ___
 
-###  _findDbNodes
+### `Private` _findDbNodes
 
-▸ **_findDbNodes**(`onFound`: FoundNode): *Promise‹void›*
+▸ **_findDbNodes**(`onFound`: FoundNodeFunction): *Promise‹void›*
 
-*Inherited from [Trie](_basetrie_.trie.md).[_findDbNodes](_basetrie_.trie.md#_finddbnodes)*
+*Inherited from [Trie](_basetrie_.trie.md).[_findDbNodes](_basetrie_.trie.md#private-_finddbnodes)*
 
-*Defined in [baseTrie.ts:302](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L302)*
+*Defined in [baseTrie.ts:740](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L740)*
+
+Finds all nodes that are stored directly in the db
+(some nodes are stored raw inside other nodes)
+called by {@link ScratchReadStream}
 
 **Parameters:**
 
 Name | Type |
 ------ | ------ |
-`onFound` | FoundNode |
+`onFound` | FoundNodeFunction |
 
 **Returns:** *Promise‹void›*
 
@@ -294,19 +305,20 @@ ___
 
 ### `Private` _findValueNodes
 
-▸ **_findValueNodes**(`onFound`: FoundNode): *Promise‹void›*
+▸ **_findValueNodes**(`onFound`: FoundNodeFunction): *Promise‹void›*
 
 *Inherited from [Trie](_basetrie_.trie.md).[_findValueNodes](_basetrie_.trie.md#private-_findvaluenodes)*
 
-*Defined in [baseTrie.ts:280](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L280)*
+*Defined in [baseTrie.ts:756](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L756)*
 
-Finds all nodes that store k,v values.
+Finds all nodes that store k,v values
+called by {@link TrieReadStream}
 
 **Parameters:**
 
 Name | Type |
 ------ | ------ |
-`onFound` | FoundNode |
+`onFound` | FoundNodeFunction |
 
 **Returns:** *Promise‹void›*
 
@@ -320,7 +332,7 @@ ___
 
 *Overrides [Trie](_basetrie_.trie.md).[_formatNode](_basetrie_.trie.md#private-_formatnode)*
 
-*Defined in [checkpointTrie.ts:149](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/checkpointTrie.ts#L149)*
+*Defined in [checkpointTrie.ts:152](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/checkpointTrie.ts#L152)*
 
 Formats node to be saved by `levelup.batch`.
 
@@ -345,7 +357,7 @@ ___
 
 *Inherited from [Trie](_basetrie_.trie.md).[_lookupNode](_basetrie_.trie.md#private-_lookupnode)*
 
-*Defined in [baseTrie.ts:194](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L194)*
+*Defined in [baseTrie.ts:314](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L314)*
 
 Retrieves a node from db by hash.
 
@@ -359,35 +371,15 @@ Name | Type |
 
 ___
 
-### `Private` _putNode
-
-▸ **_putNode**(`node`: TrieNode): *Promise‹void›*
-
-*Inherited from [Trie](_basetrie_.trie.md).[_putNode](_basetrie_.trie.md#private-_putnode)*
-
-*Defined in [baseTrie.ts:215](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L215)*
-
-Writes a single node to db.
-
-**Parameters:**
-
-Name | Type |
------- | ------ |
-`node` | TrieNode |
-
-**Returns:** *Promise‹void›*
-
-___
-
 ### `Private` _saveStack
 
 ▸ **_saveStack**(`key`: Nibbles, `stack`: TrieNode[], `opStack`: BatchDBOp[]): *Promise‹void›*
 
 *Inherited from [Trie](_basetrie_.trie.md).[_saveStack](_basetrie_.trie.md#private-_savestack)*
 
-*Defined in [baseTrie.ts:525](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L525)*
+*Defined in [baseTrie.ts:567](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L567)*
 
-Saves a stack.
+Saves a stack of nodes to the database.
 
 **Parameters:**
 
@@ -401,13 +393,31 @@ Name | Type | Description |
 
 ___
 
+###  _setRoot
+
+▸ **_setRoot**(`value?`: Buffer): *void*
+
+*Inherited from [Trie](_basetrie_.trie.md).[_setRoot](_basetrie_.trie.md#_setroot)*
+
+*Defined in [baseTrie.ts:75](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L75)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`value?` | Buffer |
+
+**Returns:** *void*
+
+___
+
 ### `Private` _updateNode
 
 ▸ **_updateNode**(`k`: Buffer, `value`: Buffer, `keyRemainder`: Nibbles, `stack`: TrieNode[]): *Promise‹void›*
 
 *Inherited from [Trie](_basetrie_.trie.md).[_updateNode](_basetrie_.trie.md#private-_updatenode)*
 
-*Defined in [baseTrie.ts:320](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L320)*
+*Defined in [baseTrie.ts:336](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L336)*
 
 Updates a node.
 
@@ -426,11 +436,11 @@ ___
 
 ### `Private` _walkTrie
 
-▸ **_walkTrie**(`root`: Buffer, `onNode`: FoundNode): *Promise‹void›*
+▸ **_walkTrie**(`root`: Buffer, `onFound`: FoundNodeFunction): *Promise‹void›*
 
 *Inherited from [Trie](_basetrie_.trie.md).[_walkTrie](_basetrie_.trie.md#private-_walktrie)*
 
-*Defined in [baseTrie.ts:426](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L426)*
+*Defined in [baseTrie.ts:208](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L208)*
 
 Walks a trie until finished.
 
@@ -439,7 +449,7 @@ Walks a trie until finished.
 Name | Type | Description |
 ------ | ------ | ------ |
 `root` | Buffer | - |
-`onNode` | FoundNode | callback to call when a node is found |
+`onFound` | FoundNodeFunction | callback to call when a node is found |
 
 **Returns:** *Promise‹void›*
 
@@ -453,7 +463,7 @@ ___
 
 *Inherited from [Trie](_basetrie_.trie.md).[batch](_basetrie_.trie.md#batch)*
 
-*Defined in [baseTrie.ts:748](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L748)*
+*Defined in [baseTrie.ts:639](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L639)*
 
 The given hash of operations (key additions or deletions) are executed on the DB
 
@@ -483,7 +493,7 @@ ___
 
 *Inherited from [Trie](_basetrie_.trie.md).[checkRoot](_basetrie_.trie.md#checkroot)*
 
-*Defined in [baseTrie.ts:764](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L764)*
+*Defined in [baseTrie.ts:86](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L86)*
 
 Checks if a given root exists.
 
@@ -503,7 +513,7 @@ ___
 
 *Inherited from [CheckpointTrie](_checkpointtrie_.checkpointtrie.md).[checkpoint](_checkpointtrie_.checkpointtrie.md#checkpoint)*
 
-*Defined in [checkpointTrie.ts:35](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/checkpointTrie.ts#L35)*
+*Defined in [checkpointTrie.ts:38](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/checkpointTrie.ts#L38)*
 
 Creates a checkpoint that can later be reverted to or committed.
 After this is called, no changes to the trie will be permanently saved until `commit` is called.
@@ -519,7 +529,7 @@ ___
 
 *Inherited from [CheckpointTrie](_checkpointtrie_.checkpointtrie.md).[commit](_checkpointtrie_.checkpointtrie.md#commit)*
 
-*Defined in [checkpointTrie.ts:50](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/checkpointTrie.ts#L50)*
+*Defined in [checkpointTrie.ts:53](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/checkpointTrie.ts#L53)*
 
 Commits a checkpoint to disk, if current checkpoint is not nested.
 If nested, only sets the parent checkpoint as current checkpoint.
@@ -536,7 +546,7 @@ ___
 
 *Overrides [CheckpointTrie](_checkpointtrie_.checkpointtrie.md).[copy](_checkpointtrie_.checkpointtrie.md#copy)*
 
-*Defined in [secure.ts:55](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/secure.ts#L55)*
+*Defined in [secure.ts:90](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/secure.ts#L90)*
 
 Returns a copy of the underlying trie with the interface of SecureTrie.
 
@@ -556,7 +566,7 @@ ___
 
 *Inherited from [Trie](_basetrie_.trie.md).[createReadStream](_basetrie_.trie.md#createreadstream)*
 
-*Defined in [baseTrie.ts:723](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L723)*
+*Defined in [baseTrie.ts:722](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L722)*
 
 The `data` event is given an `Object` that has two properties; the `key` and the `value`. Both should be Buffers.
 
@@ -572,7 +582,7 @@ ___
 
 *Overrides [Trie](_basetrie_.trie.md).[del](_basetrie_.trie.md#del)*
 
-*Defined in [secure.ts:91](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/secure.ts#L91)*
+*Defined in [secure.ts:48](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/secure.ts#L48)*
 
 Deletes a value given a `key`.
 
@@ -592,10 +602,10 @@ ___
 
 *Inherited from [Trie](_basetrie_.trie.md).[findPath](_basetrie_.trie.md#findpath)*
 
-*Defined in [baseTrie.ts:226](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L226)*
+*Defined in [baseTrie.ts:149](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L149)*
 
 Tries to find a path to the node for the given key.
-It returns a `stack` of nodes to the closet node.
+It returns a `stack` of nodes to the closest node.
 
 **Parameters:**
 
@@ -613,7 +623,7 @@ ___
 
 *Overrides [Trie](_basetrie_.trie.md).[get](_basetrie_.trie.md#get)*
 
-*Defined in [secure.ts:66](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/secure.ts#L66)*
+*Defined in [secure.ts:23](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/secure.ts#L23)*
 
 Gets a value given a `key`
 
@@ -635,7 +645,7 @@ ___
 
 *Overrides [Trie](_basetrie_.trie.md).[put](_basetrie_.trie.md#put)*
 
-*Defined in [secure.ts:78](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/secure.ts#L78)*
+*Defined in [secure.ts:35](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/secure.ts#L35)*
 
 Stores a given `value` at the given `key`.
 For a falsey value, use the original key to avoid double hashing the key.
@@ -657,7 +667,7 @@ ___
 
 *Inherited from [CheckpointTrie](_checkpointtrie_.checkpointtrie.md).[revert](_checkpointtrie_.checkpointtrie.md#revert)*
 
-*Defined in [checkpointTrie.ts:70](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/checkpointTrie.ts#L70)*
+*Defined in [checkpointTrie.ts:73](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/checkpointTrie.ts#L73)*
 
 Reverts the trie to the state it was at when `checkpoint` was first called.
 If during a nested checkpoint, sets root to most recent checkpoint, and sets
@@ -667,31 +677,13 @@ parent checkpoint as current.
 
 ___
 
-###  setRoot
-
-▸ **setRoot**(`value?`: Buffer): *void*
-
-*Inherited from [Trie](_basetrie_.trie.md).[setRoot](_basetrie_.trie.md#setroot)*
-
-*Defined in [baseTrie.ts:131](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L131)*
-
-**Parameters:**
-
-Name | Type |
------- | ------ |
-`value?` | Buffer |
-
-**Returns:** *void*
-
-___
-
 ### `Static` createProof
 
 ▸ **createProof**(`trie`: [SecureTrie](_secure_.securetrie.md), `key`: Buffer): *Promise‹[Proof](../modules/_basetrie_.md#proof)›*
 
 *Overrides [Trie](_basetrie_.trie.md).[createProof](_basetrie_.trie.md#static-createproof)*
 
-*Defined in [secure.ts:33](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/secure.ts#L33)*
+*Defined in [secure.ts:68](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/secure.ts#L68)*
 
 Creates a proof that can be verified using [SecureTrie.verifyProof](_secure_.securetrie.md#static-verifyproof).
 
@@ -712,7 +704,7 @@ ___
 
 *Inherited from [Trie](_basetrie_.trie.md).[fromProof](_basetrie_.trie.md#static-fromproof)*
 
-*Defined in [baseTrie.ts:62](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L62)*
+*Defined in [baseTrie.ts:657](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/baseTrie.ts#L657)*
 
 Saves the nodes from a proof into the trie. If no trie is provided a new one wil be instantiated.
 
@@ -733,7 +725,7 @@ ___
 
 *Overrides [Trie](_basetrie_.trie.md).[prove](_basetrie_.trie.md#static-prove)*
 
-*Defined in [secure.ts:24](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/secure.ts#L24)*
+*Defined in [secure.ts:59](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/secure.ts#L59)*
 
 prove has been renamed to [SecureTrie.createProof](_secure_.securetrie.md#static-createproof).
 
@@ -756,7 +748,7 @@ ___
 
 *Overrides [Trie](_basetrie_.trie.md).[verifyProof](_basetrie_.trie.md#static-verifyproof)*
 
-*Defined in [secure.ts:46](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/secure.ts#L46)*
+*Defined in [secure.ts:81](https://github.com/ethereumjs/merkle-patricia-tree/blob/master/src/secure.ts#L81)*
 
 Verifies a proof.
 

--- a/src/checkpointTrie.ts
+++ b/src/checkpointTrie.ts
@@ -5,6 +5,9 @@ import { DB, BatchDBOp } from './db'
 import { TrieNode } from './trieNode'
 const WriteStream = require('level-ws')
 
+/**
+ * Adds checkpointing to the {@link BaseTrie}
+ */
 export class CheckpointTrie extends BaseTrie {
   _mainDB: DB
   _scratch: ScratchDB | null
@@ -80,7 +83,7 @@ export class CheckpointTrie extends BaseTrie {
 
   /**
    * Returns a copy of the underlying trie with the interface of CheckpointTrie.
-   * @param {boolean} includeCheckpoints - If true and during a checkpoint, the copy will contain the checkpointing metadata and will use the same scratch as underlying db.
+   * @param includeCheckpoints - If true and during a checkpoint, the copy will contain the checkpointing metadata and will use the same scratch as underlying db.
    */
   copy(includeCheckpoints = true): CheckpointTrie {
     const db = this._mainDB.copy()
@@ -140,10 +143,10 @@ export class CheckpointTrie extends BaseTrie {
   /**
    * Formats node to be saved by `levelup.batch`.
    * @private
-   * @param {TrieNode} node - the node to format.
-   * @param {Boolean} topLevel - if the node is at the top level.
-   * @param {BatchDBOp[]} opStack - the opStack to push the node's data.
-   * @param {Boolean} remove - whether to remove the node (only used for CheckpointTrie).
+   * @param node - the node to format.
+   * @param topLevel - if the node is at the top level.
+   * @param opStack - the opStack to push the node's data.
+   * @param remove - whether to remove the node (only used for CheckpointTrie).
    * @returns The node's hash used as the key or the rawNode.
    */
   _formatNode(node: TrieNode, topLevel: boolean, opStack: BatchDBOp[], remove: boolean = false) {

--- a/src/db.ts
+++ b/src/db.ts
@@ -24,7 +24,7 @@ export class DB {
   /**
    * Initialize a DB instance. If `leveldb` is not provided, DB
    * defaults to an [in-memory store](https://github.com/Level/memdown).
-   * @param {Object} [leveldb] - An abstract-leveldown compliant store
+   * @param leveldb - An abstract-leveldown compliant store
    */
   constructor(leveldb?: LevelUp) {
     this._leveldb = leveldb || level()
@@ -32,7 +32,7 @@ export class DB {
 
   /**
    * Retrieves a raw value from leveldb.
-   * @param {Buffer} key
+   * @param key
    * @returns A Promise that resolves to `Buffer` if a value is found or `null` if no value is found.
    */
   async get(key: Buffer): Promise<Buffer | null> {
@@ -52,9 +52,8 @@ export class DB {
 
   /**
    * Writes a value directly to leveldb.
-   * @param {Buffer} key The key as a `Buffer`
-   * @param {Buffer} value The value to be stored
-   * @returns {Promise}
+   * @param key The key as a `Buffer`
+   * @param value The value to be stored
    */
   async put(key: Buffer, val: Buffer): Promise<void> {
     await this._leveldb.put(key, val, ENCODING_OPTS)
@@ -62,8 +61,7 @@ export class DB {
 
   /**
    * Removes a raw value in the underlying leveldb.
-   * @param {Buffer} key
-   * @returns {Promise}
+   * @param keys
    */
   async del(key: Buffer): Promise<void> {
     await this._leveldb.del(key, ENCODING_OPTS)
@@ -71,8 +69,7 @@ export class DB {
 
   /**
    * Performs a batch operation on db.
-   * @param {Array} opStack A stack of levelup operations
-   * @returns {Promise}
+   * @param opStack A stack of levelup operations
    */
   async batch(opStack: BatchDBOp[]): Promise<void> {
     await this._leveldb.batch(opStack, ENCODING_OPTS)

--- a/src/prioritizedTaskExecutor.ts
+++ b/src/prioritizedTaskExecutor.ts
@@ -4,18 +4,18 @@ interface Task {
 }
 
 export class PrioritizedTaskExecutor {
+  /** The maximum size of the pool */
   private maxPoolSize: number
+  /** The current size of the pool */
   private currentPoolSize: number
+  /** The task queue */
   private queue: Task[]
 
   /**
    * Executes tasks up to maxPoolSize at a time, other items are put in a priority queue.
    * @class PrioritizedTaskExecutor
    * @private
-   * @param {Number} maxPoolSize The maximum size of the pool
-   * @prop {Number} maxPoolSize The maximum size of the pool
-   * @prop {Number} currentPoolSize The current size of the pool
-   * @prop {Array} queue The task queue
+   * @param maxPoolSize The maximum size of the pool
    */
   constructor(maxPoolSize: number) {
     this.maxPoolSize = maxPoolSize
@@ -26,8 +26,8 @@ export class PrioritizedTaskExecutor {
   /**
    * Executes the task.
    * @private
-   * @param {Number} priority The priority of the task
-   * @param {Function} fn The function that accepts the callback, which must be called upon the task completion.
+   * @param priority The priority of the task
+   * @param fn The function that accepts the callback, which must be called upon the task completion.
    */
   execute(priority: number, fn: Function) {
     if (this.currentPoolSize < this.maxPoolSize) {
@@ -48,7 +48,7 @@ export class PrioritizedTaskExecutor {
   /**
    * Checks if the taskExecutor is finished.
    * @private
-   * @returns {Boolean} - Returns `true` if the taskExecutor is finished, otherwise returns `false`.
+   * @returns Returns `true` if the taskExecutor is finished, otherwise returns `false`.
    */
   finished(): boolean {
     return this.currentPoolSize === 0

--- a/src/secure.ts
+++ b/src/secure.ts
@@ -4,7 +4,7 @@ import { Proof } from './baseTrie'
 
 /**
  * You can create a secure Trie where the keys are automatically hashed
- * using **keccak256** by using `require('merkle-patricia-tree').SecureTrie`.
+ * using **keccak256** by using `import { SecureTrie as Trie } from 'merkle-patricia-tree'`.
  * It has the same methods and constructor as `Trie`.
  * @class SecureTrie
  * @extends Trie
@@ -16,51 +16,8 @@ export class SecureTrie extends CheckpointTrie {
   }
 
   /**
-   * prove has been renamed to [[SecureTrie.createProof]].
-   * @deprecated
-   * @param {Trie} trie
-   * @param {Buffer} key
-   */
-  static async prove(trie: SecureTrie, key: Buffer): Promise<Proof> {
-    return this.createProof(trie, key)
-  }
-
-  /**
-   * Creates a proof that can be verified using [[SecureTrie.verifyProof]].
-   * @param {Trie} trie
-   * @param {Buffer} key
-   */
-  static createProof(trie: SecureTrie, key: Buffer): Promise<Proof> {
-    const hash = keccak256(key)
-    return super.createProof(trie, hash)
-  }
-
-  /**
-   * Verifies a proof.
-   * @param {Buffer} rootHash
-   * @param {Buffer} key
-   * @param {Proof} proof
-   * @throws If proof is found to be invalid.
-   * @returns The value from the key.
-   */
-  static async verifyProof(rootHash: Buffer, key: Buffer, proof: Proof): Promise<Buffer | null> {
-    const hash = keccak256(key)
-    return super.verifyProof(rootHash, hash, proof)
-  }
-
-  /**
-   * Returns a copy of the underlying trie with the interface of SecureTrie.
-   * @param {boolean} includeCheckpoints - If true and during a checkpoint, the copy will contain the checkpointing metadata and will use the same scratch as underlying db.
-   */
-  copy(includeCheckpoints = true): SecureTrie {
-    const trie = super.copy(includeCheckpoints)
-    const db = trie.db.copy()
-    return new SecureTrie(db._leveldb, this.root)
-  }
-
-  /**
    * Gets a value given a `key`
-   * @param {Buffer} key - the key to search for
+   * @param key - the key to search for
    * @returns A Promise that resolves to `Buffer` if a value was found or `null` if no value was found.
    */
   async get(key: Buffer): Promise<Buffer | null> {
@@ -72,8 +29,8 @@ export class SecureTrie extends CheckpointTrie {
   /**
    * Stores a given `value` at the given `key`.
    * For a falsey value, use the original key to avoid double hashing the key.
-   * @param {Buffer} key
-   * @param {Buffer} value
+   * @param key
+   * @param value
    */
   async put(key: Buffer, val: Buffer): Promise<void> {
     if (!val || val.toString() === '') {
@@ -86,10 +43,53 @@ export class SecureTrie extends CheckpointTrie {
 
   /**
    * Deletes a value given a `key`.
-   * @param {Buffer} key
+   * @param key
    */
   async del(key: Buffer): Promise<void> {
     const hash = keccak256(key)
     await super.del(hash)
+  }
+
+  /**
+   * prove has been renamed to [[SecureTrie.createProof]].
+   * @deprecated
+   * @param trie
+   * @param key
+   */
+  static async prove(trie: SecureTrie, key: Buffer): Promise<Proof> {
+    return this.createProof(trie, key)
+  }
+
+  /**
+   * Creates a proof that can be verified using [[SecureTrie.verifyProof]].
+   * @param trie
+   * @param key
+   */
+  static createProof(trie: SecureTrie, key: Buffer): Promise<Proof> {
+    const hash = keccak256(key)
+    return super.createProof(trie, hash)
+  }
+
+  /**
+   * Verifies a proof.
+   * @param rootHash
+   * @param key
+   * @param proof
+   * @throws If proof is found to be invalid.
+   * @returns The value from the key.
+   */
+  static async verifyProof(rootHash: Buffer, key: Buffer, proof: Proof): Promise<Buffer | null> {
+    const hash = keccak256(key)
+    return super.verifyProof(rootHash, hash, proof)
+  }
+
+  /**
+   * Returns a copy of the underlying trie with the interface of SecureTrie.
+   * @param includeCheckpoints - If true and during a checkpoint, the copy will contain the checkpointing metadata and will use the same scratch as underlying db.
+   */
+  copy(includeCheckpoints = true): SecureTrie {
+    const trie = super.copy(includeCheckpoints)
+    const db = trie.db.copy()
+    return new SecureTrie(db._leveldb, this.root)
   }
 }

--- a/src/util/hex.ts
+++ b/src/util/hex.ts
@@ -2,8 +2,8 @@ import { Nibbles } from '../trieNode'
 
 /**
  * Prepends hex prefix to an array of nibbles.
- * @param {Nibbles} key - Array of nibbles
- * @returns {Nibbles} - returns buffer of encoded data
+ * @param key - Array of nibbles
+ * @returns returns buffer of encoded data
  **/
 export function addHexPrefix(key: Nibbles, terminator: boolean): Nibbles {
   // odd
@@ -24,7 +24,7 @@ export function addHexPrefix(key: Nibbles, terminator: boolean): Nibbles {
 
 /**
  * Removes hex prefix of an array of nibbles.
- * @param {Nibbles} val - Array of nibbles
+ * @param val - Array of nibbles
  * @private
  */
 export function removeHexPrefix(val: Nibbles): Nibbles {
@@ -39,7 +39,7 @@ export function removeHexPrefix(val: Nibbles): Nibbles {
 
 /**
  * Returns true if hex-prefixed path is for a terminating (leaf) node.
- * @param {Nibbles} key - a hex-prefixed array of nibbles
+ * @param key - a hex-prefixed array of nibbles
  * @private
  */
 export function isTerminator(key: Nibbles): boolean {

--- a/src/util/nibbles.ts
+++ b/src/util/nibbles.ts
@@ -3,7 +3,7 @@ import { Nibbles } from '../trieNode'
 /**
  * Converts a buffer to a nibble array.
  * @private
- * @param {Buffer} key
+ * @param key
  */
 export function bufferToNibbles(key: Buffer): Nibbles {
   const bkey = Buffer.from(key)
@@ -22,7 +22,7 @@ export function bufferToNibbles(key: Buffer): Nibbles {
 /**
  * Converts a nibble array into a buffer.
  * @private
- * @param {Nibbles} arr - Nibble array
+ * @param arr - Nibble array
  */
 export function nibblesToBuffer(arr: Nibbles): Buffer {
   let buf = Buffer.alloc(arr.length / 2)
@@ -36,8 +36,8 @@ export function nibblesToBuffer(arr: Nibbles): Buffer {
 /**
  * Returns the number of in order matching nibbles of two give nibble arrays.
  * @private
- * @param {Nibbles} nib1
- * @param {Nibbles} nib2
+ * @param nib1
+ * @param nib2
  */
 export function matchingNibbleLength(nib1: Nibbles, nib2: Nibbles): number {
   let i = 0
@@ -49,8 +49,8 @@ export function matchingNibbleLength(nib1: Nibbles, nib2: Nibbles): number {
 
 /**
  * Compare two nibble array keys.
- * @param {Nibbles} keyA
- * @param {Nibbles} keyB
+ * @param keyA
+ * @param keyB
  */
 export function doKeysMatch(keyA: Nibbles, keyB: Nibbles): boolean {
   const length = matchingNibbleLength(keyA, keyB)


### PR DESCRIPTION
This PR targets to make the `BaseTrie` code from MPT more readable and do some basic clean up.

Following changes:

- Improved constructor documentation
- Removed redundant @param type documentation on all files
- Made `Trie.setRoot()` private
- Reordering of `BaseTrie` functionality to get to more intuitive function clusters
- Various code doc additions
- Explicitly defined (so: not inlined) onFound functions in Trie for better code readability
- Documentation rebuild

It might be easiest to review this PR by going along commit-by-commit.