### PR TITLE
Fix double serialize in CheckpointTrie._formatNode()

### DIFF
--- a/src/checkpointTrie.ts
+++ b/src/checkpointTrie.ts
@@ -1,8 +1,7 @@
 import { Trie as BaseTrie } from './baseTrie'
 import { ScratchReadStream } from './scratchReadStream'
 import { ScratchDB } from './scratch'
-import { DB, BatchDBOp } from './db'
-import { TrieNode } from './trieNode'
+import { DB } from './db'
 const WriteStream = require('level-ws')
 
 /**
@@ -138,39 +137,5 @@ export class CheckpointTrie extends BaseTrie {
     const trie = new BaseTrie(scratch._leveldb, this.root)
     trie.db = scratch
     return new ScratchReadStream(trie)
-  }
-
-  /**
-   * Formats node to be saved by `levelup.batch`.
-   * @private
-   * @param node - the node to format.
-   * @param topLevel - if the node is at the top level.
-   * @param opStack - the opStack to push the node's data.
-   * @param remove - whether to remove the node (only used for CheckpointTrie).
-   * @returns The node's hash used as the key or the rawNode.
-   */
-  _formatNode(node: TrieNode, topLevel: boolean, opStack: BatchDBOp[], remove: boolean = false) {
-    const rlpNode = node.serialize()
-
-    if (rlpNode.length >= 32 || topLevel) {
-      const hashRoot = node.hash()
-
-      if (remove && this.isCheckpoint) {
-        opStack.push({
-          type: 'del',
-          key: hashRoot,
-        })
-      } else {
-        opStack.push({
-          type: 'put',
-          key: hashRoot,
-          value: rlpNode,
-        })
-      }
-
-      return hashRoot
-    }
-
-    return node.raw()
   }
 }


### PR DESCRIPTION
This PR fixes the double-execution of Node serialization in CheckpointTrie._formatNode() as well as moves a unified `_formatNode()` to `BaseTrie` (the added somewhat dummy `isCheckpoint()` getter there avoids a TypeScript error) to remove redundancy.

This gives a significant performance increase when running the checkpointing benchmarks:

Run on PR:

```shell
$ ts-node benchmarks/checkpointing.ts && ts-node benchmarks/checkpointing.ts && ts-node benchmarks/checkpointing.ts && ts-node benchmarks/checkpointing.ts && ts-node benchmarks/checkpointing.ts
benchmarks/checkpointing.ts | average execution time: 0s 148.515ms
benchmarks/checkpointing.ts | average execution time: 0s 146.228ms
benchmarks/checkpointing.ts | average execution time: 0s 150.828ms
benchmarks/checkpointing.ts | average execution time: 0s 146.222ms
benchmarks/checkpointing.ts | average execution time: 0s 152.767ms

$ ts-node benchmarks/checkpointing.ts && ts-node benchmarks/checkpointing.ts && ts-node benchmarks/checkpointing.ts && ts-node benchmarks/checkpointing.ts && ts-node benchmarks/checkpointing.ts
benchmarks/checkpointing.ts | average execution time: 0s 146.98ms
benchmarks/checkpointing.ts | average execution time: 0s 144.115ms
benchmarks/checkpointing.ts | average execution time: 0s 156.19ms
benchmarks/checkpointing.ts | average execution time: 0s 148.622ms
benchmarks/checkpointing.ts | average execution time: 0s 149.105ms
```

Run on `master`:

```shell
$ ts-node benchmarks/checkpointing.ts && ts-node benchmarks/checkpointing.ts && ts-node benchmarks/checkpointing.ts && ts-node benchmarks/checkpointing.ts && ts-node benchmarks/checkpointing.ts
benchmarks/checkpointing.ts | average execution time: 0s 172.482ms
benchmarks/checkpointing.ts | average execution time: 0s 176.066ms
benchmarks/checkpointing.ts | average execution time: 0s 181.225ms
benchmarks/checkpointing.ts | average execution time: 0s 180.5ms
benchmarks/checkpointing.ts | average execution time: 0s 172.593ms

$ ts-node benchmarks/checkpointing.ts && ts-node benchmarks/checkpointing.ts && ts-node benchmarks/checkpointing.ts && ts-node benchmarks/checkpointing.ts && ts-node benchmarks/checkpointing.ts
benchmarks/checkpointing.ts | average execution time: 0s 183.217ms
benchmarks/checkpointing.ts | average execution time: 0s 173.598ms
benchmarks/checkpointing.ts | average execution time: 0s 174.573ms
benchmarks/checkpointing.ts | average execution time: 0s 172.899ms
benchmarks/checkpointing.ts | average execution time: 0s 172.908ms