### PR TITLE
Add simple profiling / Basic benchmark & README update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist
 dist.browser
 .nyc_output
 coverage
+benchmarks/*.js

--- a/README.md
+++ b/README.md
@@ -128,6 +128,24 @@ Additional examples with detailed explanations are available [here](https://gith
 
 `npm test`
 
+# BENCHMARKS
+
+There are two simple **benchmarks** for random `PUT` operations on the tree (`random.ts`) as well as checkpointing (`checkpointing.ts`)
+in the `benchmarks` folder.
+
+Benchmarks can be run with:
+
+```shell
+npm run benchmarks
+```
+
+For running a **profiler** on the `random.ts` benchmark and generate a flamegraph with [0x](https://github.com/davidmarkclements/0x)
+you can use:
+
+```shell
+npm run profiling
+```
+
 # REFERENCES
 
 - Wiki

--- a/README.md
+++ b/README.md
@@ -130,8 +130,12 @@ Additional examples with detailed explanations are available [here](https://gith
 
 # BENCHMARKS
 
-There are two simple **benchmarks** for random `PUT` operations on the tree (`random.ts`) as well as checkpointing (`checkpointing.ts`)
-in the `benchmarks` folder.
+There are two simple **benchmarks** in the `benchmarks` folder:
+
+- `random.ts` runs random `PUT` operations on the tree.
+- `checkpointing.ts` runs checkpoints and commits between `PUT` operations.
+
+A third benchmark using mainnet data to simulate real load is also under consideration.
 
 Benchmarks can be run with:
 
@@ -139,12 +143,13 @@ Benchmarks can be run with:
 npm run benchmarks
 ```
 
-For running a **profiler** on the `random.ts` benchmark and generate a flamegraph with [0x](https://github.com/davidmarkclements/0x)
-you can use:
+To run a **profiler** on the `random.ts` benchmark and generate a flamegraph with [0x](https://github.com/davidmarkclements/0x) you can use:
 
 ```shell
 npm run profiling
 ```
+
+0x processes the stacks and generates a profile folder (`<pid>.0x`) containing [`flamegraph.html`](https://github.com/davidmarkclements/0x/blob/master/docs/ui.md).
 
 # REFERENCES
 

--- a/benchmarks/checkpointing.ts
+++ b/benchmarks/checkpointing.ts
@@ -1,8 +1,8 @@
 import { pseudoRandomBytes } from 'crypto'
 import { CheckpointTrie } from '../dist'
 
-const iterations = 500
-const samples = 20
+const iterations = 5000
+const samples = 5
 
 const iterTest = async (numOfIter: number): Promise<Array<number>> => {
   return new Promise(async (resolve) => {
@@ -17,25 +17,27 @@ const iterTest = async (numOfIter: number): Promise<Array<number>> => {
     let hrstart = process.hrtime()
     let numOfOps = 0
     let trie = new CheckpointTrie()
-
     for (let i = 0; i < numOfIter; i++) {
-      await trie.put(vals[i], keys[i])
       trie.checkpoint()
+      await trie.put(vals[i], keys[i])
       await trie.get(Buffer.from('test'))
       numOfOps++
       if (numOfOps === numOfIter) {
         const hrend = process.hrtime(hrstart)
         resolve(hrend)
       }
+      trie.commit()
     }
   })
 }
 
 const go = async () => {
-  let i = 0
+  let i = 1
   let avg = [0, 0]
 
+  console.log(`Benchmark 'checkpointing' starting...`)
   while (i <= samples) {
+    console.log(`Sample ${i} with ${iterations} iterations.`)
     const hrend = await iterTest(iterations)
     avg[0] += hrend[0]
     avg[1] += hrend[1]

--- a/benchmarks/random.ts
+++ b/benchmarks/random.ts
@@ -1,32 +1,32 @@
 // https://github.com/ethereum/wiki/wiki/Benchmarks
-'use strict'
-import { keccak256 } from 'ethereumjs-util'
-import { BaseTrie } from '../dist'
+const crypto = require('crypto')
+import { CheckpointTrie } from '../dist'
 
-const ROUNDS = 1000
+const ROUNDS = 50000
 const SYMMETRIC = true
-const ERA_SIZE = 1000
+const ERA_SIZE = 10000
 
-const trie = new BaseTrie()
-let seed = Buffer.alloc(32).fill(0)
+const trie = new CheckpointTrie()
 
 const run = async (): Promise<void> => {
+  console.log(`Benchmark 'random' starting...`)
   let i = 0
   while (i <= ROUNDS) {
-    seed = keccak256(seed)
+    let key = crypto.randomBytes(32)
 
     const genRoot = () => {
       if (i % ERA_SIZE === 0) {
-        seed = trie.root
+        key = trie.root
+        console.log(`${i} rounds.`)
       }
     }
 
     if (SYMMETRIC) {
-      await trie.put(seed, seed)
+      await trie.put(key, key)
       genRoot()
     } else {
-      const val = keccak256(seed)
-      await trie.put(seed, val)
+      const value = crypto.randomBytes(32)
+      await trie.put(key, value)
       genRoot()
     }
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   ],
   "browser": "dist.browser/index.js",
   "scripts": {
-    "benchmarks": "npm run build && ts-node benchmarks/index.ts",
+    "benchmarks": "npm run build && ts-node benchmarks/checkpointing.ts && ts-node benchmarks/random.ts",
+    "profiling": "npm run build && tsc --target ES5 benchmarks/random.ts && 0x benchmarks/random.js",
     "build": "tsc -p tsconfig.prod.json && tsc -p tsconfig.browser.json",
     "prepublishOnly": "npm run test && npm run build",
     "coverage": "nyc --reporter=lcov npm run test:node",
@@ -58,6 +59,7 @@
     "semaphore-async-await": "^1.5.1"
   },
   "devDependencies": {
+    "0x": "^4.9.1",
     "@ethereumjs/config-nyc": "^1.1.1",
     "@ethereumjs/config-prettier": "^1.1.1",
     "@ethereumjs/config-tsc": "^1.1.1",


### PR DESCRIPTION
Hi @alcuadrado, I thought it would be the most sustainable option to create a PR on your request to send the MPT flamegraph, especially since sending around an HTML flamegraph is a bit tricky.

The PR integrates basic profiling on the library, I also updated the `random.ts` benchmark a bit, this was actually already quite similar before in comparison to my code I had for profiling.

This PR is of course just one small step to first-introduce this basic profiling here. Everyone feel free to change on everything on subsequent PRs. Once this is merged it should be easily doable to generate a flamegraph with:

```shell
npm run profiling
```