### PR TITLE
Use binary search in the prioritized task executor

### DIFF
--- a/src/prioritizedTaskExecutor.ts
+++ b/src/prioritizedTaskExecutor.ts
@@ -35,13 +35,40 @@ export class PrioritizedTaskExecutor {
       fn(() => {
         this.currentPoolSize--
         if (this.queue.length > 0) {
-          this.queue.sort((a, b) => b.priority - a.priority)
           const item = this.queue.shift()
           this.execute(item!.priority, item!.fn)
         }
       })
     } else {
-      this.queue.push({ priority, fn })
+      if (this.queue.length == 0) {
+        this.queue.push({ priority, fn })
+      } else {
+        // insert the item in the queue using binary search
+        let left = 0
+        let right = this.queue.length
+        let mid = () => {
+          return Math.floor(left + (right - left) / 2)
+        }
+        while (true) {
+          let index = mid()
+          let value = this.queue[index].priority
+          console.log(left, right, index, value)
+          if (value == priority) {
+            this.queue.splice(index, 0, { priority, fn })
+            break
+          }
+          if (left == right) {
+            this.queue.splice(left, 0, { priority, fn })
+            break
+          }
+
+          if (value > priority) {
+            left = index
+          } else {
+            right = index
+          }
+        }
+      }
     }
   }
 

--- a/test/prioritizedTaskExecutor.spec.ts
+++ b/test/prioritizedTaskExecutor.spec.ts
@@ -1,24 +1,39 @@
 import * as tape from 'tape'
 import { PrioritizedTaskExecutor } from '../src/prioritizedTaskExecutor'
 
-const taskExecutor = new PrioritizedTaskExecutor(2)
-
-tape('prioritized task executor test', function (t) {
-  const tasks = [1, 2, 3, 4]
-  const callbacks = [] as any
-  const executionOrder = [] as any
-  tasks.forEach(function (task) {
-    taskExecutor.execute(task, function (cb: Function) {
-      executionOrder.push(task)
-      callbacks.push(cb)
+tape('prioritized task executor test', function (t: any) {
+  t.test('should execute tasks in the right order', (st: any) => {
+    const taskExecutor = new PrioritizedTaskExecutor(2)
+    const tasks = [1, 2, 3, 4]
+    const callbacks = [] as any
+    const executionOrder = [] as any
+    tasks.forEach(function (task) {
+      taskExecutor.execute(task, function (cb: Function) {
+        executionOrder.push(task)
+        callbacks.push(cb)
+      })
     })
+
+    callbacks.forEach(function (callback: Function) {
+      callback()
+    })
+
+    const expectedExecutionOrder = [1, 2, 4, 3]
+    st.deepEqual(executionOrder, expectedExecutionOrder)
+    st.end()
   })
 
-  callbacks.forEach(function (callback: Function) {
-    callback()
+  t.test('should queue tasks in the right order', (st: any) => {
+    const priorityList = [0, 1, 0, 2, 0, 1, 0, 2, 2, 1]
+    const PTE = new PrioritizedTaskExecutor(0) // this ensures that no task actually gets executed, so this essentially just checks the sort algorithm
+    priorityList.map((priority) => {
+      PTE.execute(priority, () => {})
+    })
+    // have to cast the PTE as <any> to access the private queue
+    st.deepEqual(
+      (<any>PTE).queue.map((task: any) => task.priority),
+      priorityList.sort((a: any, b: any) => b - a),
+    )
+    st.end()
   })
-
-  const expectedExecutionOrder = [1, 2, 4, 3]
-  t.deepEqual(executionOrder, expectedExecutionOrder)
-  t.end()
 })


### PR DESCRIPTION
In the Prioritized Task Executor originally every time when a task finishes, the priority list is sorted again. This is not optimal as we can do this directly when we insert it. For instance, `_walkTrie` is expected to get a gigantic queue at some point if we have a large MPT, which means we might be sorting this large array every time MPT finds a new item.

There is possibly one problem here: a task might finish while the insertion algorithm is ran. I think we need a lock mechanism here? Suggestions?